### PR TITLE
Pause automatic publication for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ env:
   - secure: "VN/dLt9WsmTxswfh1yTbttRsHHAZ3tlxoixu3OPO/arLhpbYDyqHHVF3If8LogWSK/B6hG8CBgGTm4ixtvP5sZ2AaNeyCT3VvcxM2DUXAQMBFsIXVkihuYPZBhC9SPvRGHsYyAm5Bso8QINje7sGXEXMMlaLQIkmSnpZ9wYVSPY="
 script:
 - echo "ok"
-after_success:
-- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION"
-  --data "token=$TOKEN"'
+# after_success:
+# - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION"
+#   --data "token=$TOKEN"'


### PR DESCRIPTION
I've been told this spec is transitioning from ReSpec to Bikeshed. While it does, [commits are still triggering automatic publication, and always failing](https://www.w3.org/Search/Mail/Public/search?keywords=&hdr-1-name=subject&hdr-1-query=clipboard-apis&index-grp=Public_FULL&index-type=t&type-index=public-tr-notifications).

Avoid calling Echidna until the repo is set up to submit a valid WD again.

cf #36