### PR TITLE
Emphasize visability in the "pick target"-algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1323,17 +1323,9 @@ urlPrefix: https://w3c.github.io/permissions/#dom-permissionstate-; type: dfn;
 
 		1. Let |target| be set as follows:
 
-			1. If the context is editable, then
-
-				1. Set |target| to be the element that contains the
-					start of the selection in document order, or
-					[=the body element=] if there is no selection or cursor.
-
-			1. Else, if the context is not editable, then
-
-				1. Set |target| to be the element that contains the
-					start of the selection in document order, or
-					[=the body element=] if there is no selection or cursor.
+			1. Set |target| to be the element that contains the
+				start of the selection in document order, or
+				[=the body element=] if there is no selection or cursor.
 
 		1. Process the event as follows:
 

--- a/index.bs
+++ b/index.bs
@@ -1324,8 +1324,8 @@ urlPrefix: https://w3c.github.io/permissions/#dom-permissionstate-; type: dfn;
 		1. Let |target| be set as follows:
 
 			1. Set |target| to be the element that contains the
-				start of the selection in document order, or
-				[=the body element=] if there is no selection or cursor.
+				start of the visible selection or cursor in document order,
+				or [=the body element=] if there is no visible selection or cursor.
 
 		1. Process the event as follows:
 


### PR DESCRIPTION
This change addresses the ambiguity of unfocused and hidden
selections (#57) by stating that only a visible selection can be a
ClipboardEvent-target.