### PR TITLE
Specify NotAllowedError when permission is not granted

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -639,7 +639,7 @@ urlPrefix: https://w3c.github.io/permissions/#dom-permissionstate-; type: dfn;
 
 				1. Let |r| be the result of running [=check clipboard read permission=] [=in parallel=]
 				
-				1. If |r| is not "granted", then reject |p|
+				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |data| be a copy of the [=system clipboard data=].
 				
@@ -673,7 +673,7 @@ urlPrefix: https://w3c.github.io/permissions/#dom-permissionstate-; type: dfn;
 
 				1. Let |r| be the result of running [=check clipboard write permission=] [=in parallel=]
 				
-				1. If |r| is not "granted", then reject |p|
+				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |cleanItemList| be an empty {{DataTransferItemList}}.
 
@@ -716,7 +716,7 @@ urlPrefix: https://w3c.github.io/permissions/#dom-permissionstate-; type: dfn;
 
 				1. Let |r| be the result of running [=check clipboard write permission=] [=in parallel=]
 				
-				1. If |r| is not "granted", then reject |p|
+				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |newItemList| be an empty {{DataTransferItemList}}.
 


### PR DESCRIPTION
This was previously only done for the `read` method, this patch adds it to `readText`, `write` and `writeText` as well.

Fixes #76 