### PR TITLE
Fixup some references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -53,11 +53,6 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 <pre class="biblio">
 {
-	"HTMLEA": {
-		"title": "HTML Editing APIs",
-		"href": "https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html",
-		"authors": ["Aryeh Gregor. W3C Editing APIs CG."]
-	 },
 	"HTMLLS": {
 		"title": "HTML Living Standard",
 		"href": "https://html.spec.whatwg.org/multipage/",

--- a/index.bs
+++ b/index.bs
@@ -55,7 +55,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 {
 	"MICROSOFT-CLIP-OP": {
 		"title": "About DHTML Data Transfer. Microsoft Developer Network.",
-		"href": "http://msdn.microsoft.com/en-us/library/ms537658.aspx"
+		"href": "https://msdn.microsoft.com/en-us/ie/ms537658(v=vs.94)"
 	}
 }
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -53,11 +53,6 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 <pre class="biblio">
 {
-	"HTMLLS": {
-		"title": "HTML Living Standard",
-		"href": "https://html.spec.whatwg.org/multipage/",
-		"authors": [ "Ian Hickson. WHATWG." ]
-	 },
 	"MICROSOFT-CLIP-OP": {
 		"title": "About DHTML Data Transfer. Microsoft Developer Network.",
 		"href": "http://msdn.microsoft.com/en-us/library/ms537658.aspx"
@@ -1496,7 +1491,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			uses the {{ClipboardEvent}} interface, at |target|.
 
 			Implementation requirements for access to data during event
-			dispatch are defined in [[!HTMLLS]]. Some additional clipboard
+			dispatch are defined in [[!HTML]]. Some additional clipboard
 			event-specific processing rules are given below:
 
 			Issue: Why here? Why not in the HTML spec?

--- a/index.bs
+++ b/index.bs
@@ -53,11 +53,6 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 <pre class="biblio">
 {
-	"RFC2392": {
-		"title": "Content-ID and Message-ID Uniform Resource Locators. August 1998. Internet RFC 2392.",
-		"href": "http://www.ietf.org/rfc/rfc2392.txt",
-		"authors": [ "E. Levinson" ]
-	},
 	"HTMLEA": {
 		"title": "HTML Editing APIs",
 		"href": "https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html",
@@ -81,9 +76,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	<i>This section is non-normative.</i>
 
 	This specification defines how the system clipboard is exposed to web applications.
-	
+
 	There are two general APIs described in this specification:
-	
+
 	* Clipboard Event API - This API provides a way to hook into the common clipboard
 		operations of cutting, copying and pasting so that web application can
 		adjust the clipboard data as required.
@@ -97,7 +92,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	<i>This section is non-normative.</i>
 
 	<h3 id="change-default-clipboard-ops">Changing Default Clipboard Operations</h3>
-	
+
 		There are many scenarios where it is desireable to change the default clipboard
 		operations (cut/copy/paste). Here are a few examples:
 
@@ -133,10 +128,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		For web applications that communicate with remote devices (e.g., remote access
 		or remote shell applications), there is often a need for the clipboard data
 		to be kept in sync between the two devices.
-		
+
 		One important aspect of this use case is that it requires access to the
 		clipboard in the absense of a user gesture or interaction.
-		
+
 		<div class="example">
 		To copy the clipboard data from a remote device to the local clipboard, a web
 		application would take the remote clipboard data and then {{Clipboard/write()}}
@@ -148,18 +143,18 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		listen for [=clipboardchange=] events, {{Clipboard/read()}} from the clipboard
 		whenever it is updated, and then send the new clipboard data to the remote device.
 		</div>
-		
+
 	<h3 id="trigger-clipboard-actions">Trigger Clipboard Actions</h3>
 
 		Applications that provide an alternate interface to a user agent sometimes need
 		to be able to trigger clipboard actions in the user agent.
-		
+
 		As an example, consider a screen reader application that provides a more accessible
 		interface to a standard web browser. While the reader can display content and
 		allow the user to interact with it, actions like clipboard copy need
 		to occur in the underlying browser to ensure that the clipboard content is set
 		correctly (with any metadata added by the browser during copy).
-		
+
 <h2 id="terminolofy">Terminology</h2>
 
 	The term <dfn>editable context</dfn> means any element that is either an
@@ -174,7 +169,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 	The [=system clipboard=] has a list of clipboard items that are collectively
 	called the <dfn>system clipboard data</dfn>.
-	
+
 	* For the [[#clipboard-event-api]], the [=system clipboard data=] is
 		exposed as a {{DataTransfer}} object that mirrors the contents of the clipboard.
 
@@ -249,14 +244,14 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			The [=clipboardchange=] event fires whenever the contents of the
 			[=system clipboard=] are changed. These changes could be due to any of the
 			following (non-exhaustive):
-			
+
 			* User-initiated cut or copy actions
 			* Scripts that use the [[#async-clipboard-api]] to write to the clipboard
 			* Actions that update the clipboard outside the user agent
 
 			If the clipboard contents are changed outside the user agent, then the
 			[=clipboardchange=] event MUST fire when the user agent regains focus.
-			
+
 			Since synthetic [=cut=] and [=copy=] events do not update the [=system clipboard=],
 			they will not trigger a "clipboardchange" event.
 
@@ -265,16 +260,16 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			When the user initiates a copy action, the user agent
 			[=fire a clipboard event|fires a clipboard event=] named
 			[=copy=].
-			
+
 			If the event is not canceled, the currently selected
 			data will be copied to the [=system clipboard=].
 			The current document selection is not affected.
 
 			The [=copy=] event bubbles, is cancelable, and is composed.
-			
+
 			See [[#copy-action]] for a detailed description of the processing model for
 			this event.
-			
+
 			A synthetic [=copy=] event can be manually constructed and dispatched, but it
 			will not affect the contents of the [=system clipboard=].
 
@@ -283,7 +278,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			When the user initiates a cut action, the user agent
 			[=fire a clipboard event|fires a clipboard event=] named
 			[=cut=].
-			
+
 			In an [=editable context=], if the event is not
 			canceled the action will place the currently selected data on the
 			[=system clipboard=] and remove the selection from the document.
@@ -298,7 +293,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 			See [[#cut-action]] for a detailed description of the processing model for
 			this event.
-			
+
 			A synthetic [=cut=] event can be manually constructed and dispatched, but it
 			will not affect the contents of the document or of the [=system clipboard=].
 
@@ -320,7 +315,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 			See [[#paste-action]] for a detailed description of the processing model for
 			this event.
-			
+
 			A synthetic [=paste=] event can be manually constructed and dispatched, but it
 			will not affect the contents of the document.
 
@@ -427,13 +422,13 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	transcoding a image) are not supported by these APIs. See [[#async-clipboard-api]]
 	for a more powerful API that can support blocking or other time-consuming
 	actions.
-	
+
 	<h3 id="override-copy">Overriding the copy event</h3>
 
 		To override the default [=copy=] event behavior, a [=copy=] event
 		handler must be added and this event handler must call
 		{{Event/preventDefault()}} to cancel the event.
-		
+
 		Canceling the event is required in order for the [=system clipboard=] to be
 		updated with the data in {{ClipboardEvent/clipboardData}}.
 		If the {{ClipboardEvent}} is not canceled, then the data from the
@@ -458,7 +453,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		To override the default [=cut=] event behavior, a [=cut=] event
 		handler must be added and this event handler must call
 		{{Event/preventDefault()}} to cancel the event.
-		
+
 		Canceling the event is required in order for the [=system clipboard=] to be
 		updated with the data in {{ClipboardEvent/clipboardData}}.
 		If the {{ClipboardEvent}} is not canceled, then the data from the
@@ -468,7 +463,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		being updated (i.e., the current selection will not be removed). The event
 		handler will need to manually update the document to remove the currently
 		selected text.
-		
+
 		<pre class="example javascript">
 		// Overwrite what is copied to the clipboard.
 		document.addEventListener('cut', function(e) {
@@ -493,14 +488,14 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		To override the default [=paste=] event behavior, a [=paste=] event
 		handler must be added and this event handler must call
 		{{Event/preventDefault()}} to cancel the event.
-		
+
 		Canceling the event is required so that the user agent does not update the
 		document with data from the [=system clipboard=].
 
 		Note that canceling the [=paste=] event will also prevent the document from
 		being updated (i.e., nothing will be pasted into the document). The event
 		handler will need to manually paste the data into the document.
-		
+
 		Also note that, when pasting, the [=drag data store mode=] flag is
 		<a lt="concept dnd ro">read-only</a>, hence calling {{DataTransfer/setData()}} from a
 		[=paste=] event handler will not modify the data that is
@@ -596,7 +591,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<pre class="idl" data-highlight="webidl">
 
 		typedef sequence&lt;ClipboardItem> ClipboardItems;
-						
+
 		[SecureContext, Exposed=Window] interface Clipboard : EventTarget {
 		  Promise&lt;ClipboardItems> read();
 		  Promise&lt;DOMString> readText();
@@ -606,9 +601,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 		typedef (DOMString or Blob) ClipboardItemDataType;
 		typedef Promise&lt;ClipboardItemDataType> ClipboardItemData;
-		
+
 		callback ClipboardItemDelayedCallback = ClipboardItemData ();
-		
+
 		[Constructor(record&lt;DOMString, ClipboardItemData> items,
 		    optional ClipboardItemOptions options),
 		 Exposed=Window] interface ClipboardItem {
@@ -619,14 +614,14 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		  readonly attribute PresentationStyle presentationStyle;
 		  readonly attribute long long lastModified;
 		  readonly attribute boolean delayed;
-		  
+
 		  readonly attribute FrozenArray&lt;DOMString> types;
-		  
+
 		  Promise&lt;Blob> getType(DOMString type);
 		};
-		
+
 		enum PresentationStyle { "unspecified", "inline", "attachment" };
-		
+
 		dictionary ClipboardItemOptions {
 		  PresentationStyle presentationStyle = "unspecified";
 		};
@@ -639,11 +634,11 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		The {{Clipboard/read()}} method must run these steps:
 
 			1. Let |p| be a new [=Promise=].
-			
+
 			1. Run the following steps [=in parallel=]:
 
 				1. Let |r| be the result of running [=check clipboard read permission=] [=in parallel=]
-				
+
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |data| be a copy of the [=system clipboard data=] represented as
@@ -672,15 +667,15 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			1. Run the following steps [=in parallel=]:
 
 				1. Let |r| be the result of running [=check clipboard read permission=] [=in parallel=]
-				
+
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |data| be a copy of the [=system clipboard data=].
-				
+
 				1. Let |textData| be an empty string.
-				
+
 				1. If |data| contains a "text/plain" item |textItem|, then:
-				
+
 					1. Set |textData| to be a copy of |textItem|'s string data
 
 				1. Resolve |p| with |textData|.
@@ -702,11 +697,11 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		The {{Clipboard/write(data)}} method must run these steps:
 
 			1. Let |p| be a new [=Promise=].
-			
+
 			1. Run the following steps [=in parallel=]:
 
 				1. Let |r| be the result of running [=check clipboard write permission=] [=in parallel=]
-				
+
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |cleanItemList| be an empty sequence&lt;{{Blob}}>.
@@ -747,7 +742,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			1. Run the following steps [=in parallel=]:
 
 				1. Let |r| be the result of running [=check clipboard write permission=] [=in parallel=]
-				
+
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |newItemList| be an empty sequence&lt;{{ClipboardItem}}>.
@@ -755,12 +750,12 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				1. Let |textBlob| be a new {{Blob}} created with:
 					[=type=] attribute set to <em>text/plain;charset=utf-8</em>, and
 					[=blobParts=] set to a sequence containing the <em>string</em> |data|.
-					
+
 				1. Let |newItem| be a new {{ClipboardItem}} created with a single
-					representation: 
+					representation:
 					[=type=] attribute set to <em>text/plain8</em>, and
 					[=data=] set to |textBlob|.
-					
+
 				1. Add |newItem| to |newItemList|.
 
 				1. Replace the [=system clipboard data=] with |newItemList|.
@@ -776,7 +771,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			</pre>
 
 		</div><!-- writeText() -->
-		
+
 		</div><!-- dfn-for Clipboard -->
 
 
@@ -948,18 +943,18 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	The [[permissions]] API provides a uniform way for websites to access
 	<a>powerful feature</a>s like the clipboard. It allows websites to request permissions
 	from users and query which permissions they have.
-	
+
 	For the clipboard, two separate permissions are defined:
 	<dfn enum-value for="PermissionName">"clipboard-read"</dfn> and
 	<dfn enum-value for="PermissionName">"clipboard-write"</dfn>
-	
+
 	Note: Clipboard permissions currently only apply to the Async Clipboard API.
 	Future versions of this specification may be updated to apply this permission
 	to other Clipboard interactions.
 
 	These clipboard permissions are <a>powerful feature</a>s
 	permission-related algorithms and types are defined as follows:
-	
+
 	<dl>
 	<dt>
 		<a>permission descriptor type</a>
@@ -973,14 +968,14 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	</dd>
 
 	There are 4 clipboard permissions:
-	
+
 	* { name: "clipboard-read", allowWithoutGesture: false }
 	* { name: "clipboard-read", allowWithoutGesture: true }
 	* { name: "clipboard-write", allowWithoutGesture: false }
 	* { name: "clipboard-write", allowWithoutGesture: true }
 
 	With the following relationships:
-	
+
 	* <code>{ "clipboard-read" + true }</code> is stronger than <code>{ "clipboard-read" + false }</code>
 	* <code>{ "clipboard-write" + true }</code> is stronger than <code>{ "clipboard-write" + false }</code>
 
@@ -995,23 +990,23 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	While user agents MUST support the {{ClipboardPermissionDescriptor}} as described
 	in this specification, they, of course, retain complete control over the default
 	settings and how (or if) they are exposed to the user.
-	
+
 	<div class="example">
 		A user agent that wants to have separate user-settable read and write controls over the clipboad
 		and always require a user gesture would handle each descriptor as follows:
-		
+
 		* <code class="perm">{ "clipboard-read" + false }</code> is exposed for user control
 		* <code class="perm">{ "clipboard-read" + true }</code> is always <a>denied</a>
 		* <code class="perm">{ "clipboard-write" + false }</code> is exposed for user control
 		* <code class="perm">{ "clipboard-write" + true }</code> is always <a>denied</a>
 	</div>
-				
+
 	<div class="example">
 		A user agent that wants to automatically grant "write" access (with a gesture),
 		but have a single user-settable permission that controls full gesture-less access would
 		define "clipboard-read" as being stronger than "clipboard-write" and then handle
 		each descriptor as follows:
-		
+
 		* <code class="perm">{ "clipboard-read" + false }</code> is inherited from
 			<code class="perm">{ "clipboard-read" + true }</code>
 		* <code class="perm">{ "clipboard-read" + true }</code> is exposed for user control
@@ -1021,7 +1016,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			may be overridden by <code class="perm">{ "clipboard-read" + true }</code> because
 			"read" is stronger than "write".
 	</div>
-				
+
 	<h3 id="read-permission">Clipboard read permission</h3>
 
 		<div class="algorithm" data-algorithm="clipboard-read-permission">
@@ -1030,29 +1025,29 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		1. Let |readWithoutGesture| be the [=permission state=] of the
 			<code>{ name: "clipboard-read", allowWithoutGesture: true }</code>
 			permission.
-		
+
 		1. Let |hasGesture| be true if the current script is not running as a result of
 			direct user action, false otherwise.
-		
+
 		1. If |readWithoutGesture| is <a>granted</a>, then return true.
-		
+
 		1. If |hasGesture| then,
-		
+
 			<!-- System paste buttons don't require permission -->
 			1. Let |systemPaste| be true if the current script is running as a result of user
 				interaction with a "Paste" element created by the user agent or operating
 				system.
-		
+
 			1. If |systemPaste| is true, then return true.
-			
-			1. Return the result of [=request permission to use=] the 
+
+			1. Return the result of [=request permission to use=] the
 				<code>{ name: "clipboard-read", allowWithoutGesture: false }</code>
 				permission.
-						
+
 				Note: User agents may choose to request a stronger permission that
 				will implicitly update this permission.
-				
-		1. Return the result of [=request permission to use=] the 
+
+		1. Return the result of [=request permission to use=] the
 			<code>{ name: "clipboard-read", allowWithoutGesture: true }</code>
 			permission.
 
@@ -1066,10 +1061,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		1. Let |writeWithoutGesture| be the [=permission state=] of the
 			<code>{ name: "clipboard-write", allowWithoutGesture: true }</code>
 			permission.
-		
+
 		1. Let |hasGesture| be true if the current script is not running as a result of
 			direct user action, false otherwise.
-		
+
 		1. If |writeWithoutGesture| is <a>granted</a>, then return true.
 
 		1. If |hasGesture| then,
@@ -1078,17 +1073,17 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			1. Let |systemCopy| be true if the current script is running as a result of user
 				interaction with a "cut" or "copy" element created by the user agent or operating
 				system.
-		
+
 			1. If |systemCopy| is true, then return true.
-			
-			1. Return the result of [=request permission to use=] the 
+
+			1. Return the result of [=request permission to use=] the
 				<code>{ name: "clipboard-write", allowWithoutGesture: false }</code>
 				permission.
-						
+
 				Note: User agents may choose to request a stronger permission that
 				will implicitly update this permission.
 
-		1. Return the result of [=request permission to use=] the 
+		1. Return the result of [=request permission to use=] the
 			<code>{ name: "clipboard-write", allowWithoutGesture: true }</code>
 			permission.
 
@@ -1102,7 +1097,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	paste information can raise various security concerns.
 
 	Some example scenarios include:
-	
+
 	* A user selects a link and copies it, but a different link is copied to the clipboard.
 		The effect of this can range from an unexpected result on pasting to an attempted
 		"phishing" attack.
@@ -1110,7 +1105,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		intent that the user will run the pasted content.
 	* An image that is specially crafted to exploit bugs in the core OS image handling
 		code can be written to the clipboard.
-		
+
 	<h3 id="pasting-html">Pasting HTML and multi-part data</h3>
 
 		<em>This section is non-normative.</em>
@@ -1177,10 +1172,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		add an entry for example.jpg to the clipboardData.items list.
 
 	<h3 id="image-transcode">Transcoding images</h3>
-	
+
 		To prevent malicious image data from being placed on the clipboard, the image
 		data may be transcoded to produce a safe version of the image.
-		
+
 	<h3 id="nuisances">Nuisance considerations</h3>
 
 		Scripts may use the {{DataTransfer}} API to annoy and confuse users by
@@ -1197,10 +1192,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	Because these APIs provide access to the user's clipboard data, there are serious
 	privacy concerns due to the possibility that the clipboard will contain
 	personally-identifiable information (PII) like names, addresses, or passwords.
-	
+
 	In general, user agents <em>must</em> ensure that untrusted scripts do not get
 	uncontrolled access to a user's clipboard data through these APIs.
-	
+
 	<h3 id="privacy-events">Privacy and the Clipboard Event API</h3>
 
 		The Clipboard Event API allows scripts running in the context of a clipboard
@@ -1244,11 +1239,11 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 			User agents may opt to have this permission automatically expire sometime after
 			the user grants permission, for example, by having the permission expire:
-			
+
 			* After a set time from when the permission was first granted
 			* After a set time from the user's last visit to a site
 			* When the user navigates away from the page
-		
+
 	<h3 id="privacy-other">Other Privacy Concerns</h3>
 
 		If the user agent allows clipboard data to be read using
@@ -1407,13 +1402,13 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		1. Let |target| be set as follows:
 
 			1. If the context is editable, then
-			
+
 				1. Set |target| to be the element that contains the
 					start of the visible selection or cursor in document order,
 					or [=the body element=] if there is no visible selection or cursor.
-					
+
 			1. Else, if the context is not editable, then
-			
+
 				1. Set |target| to the focused node, or [=the body element=] if no node
 					has focus.
 
@@ -1457,7 +1452,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 								file's type is unknown.
 
 							1. Set |new-data|'s data to the file reference data.
-							
+
 							1. Add |new-data| to |clipboard-event-data|'s {{DataTransfer/items}}
 
 						1. If |clipboard-part| contains HTML- or
@@ -1480,7 +1475,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 								with [=drag data item kind=] set to
 								<em>file</em>, [=drag data item type string=]
 								set to the corresponding MIME type
-							
+
 							1. Set |new-data|'s data to be the binary or text-based data.
 
 							1. Add |new-data| to |clipboard-event-data|'s {{DataTransfer/items}}


### PR DESCRIPTION
That MICROSOFT-CLIP-OP reference is quite obsolete... maybe consider removing it entirely?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/90.html" title="Last updated on May 21, 2019, 8:20 PM UTC (6e5c7ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/90/4874398...6e5c7ae.html" title="Last updated on May 21, 2019, 8:20 PM UTC (6e5c7ae)">Diff</a>