### PR TITLE
set default for optional dictionary

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -189,7 +189,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<div id="clipboardevent-idl">
 
 		<pre class="idl" data-highlight="webidl">
-		[Constructor(DOMString type, optional ClipboardEventInit eventInitDict), Exposed=Window]
+		[Constructor(DOMString type, optional ClipboardEventInit eventInitDict = {}), Exposed=Window]
 		interface ClipboardEvent : Event {
 		  readonly attribute DataTransfer? clipboardData;
 		};


### PR DESCRIPTION
This is part of https://github.com/heycam/webidl/issues/758

For *normative* changes, the following tasks have been completed:

 * [X] Modified Web platform tests  - IDL changes will be picked up automatically. 

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [X] [Gecko](https://bugs.chromium.org/p/chromium/issues/detail?id=948139) 

The following bug needs to be fixed in Blink first:
https://bugs.chromium.org/p/chromium/issues/detail?id=948139


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/91.html" title="Last updated on Jul 11, 2019, 5:45 AM UTC (28e4885)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/91/fed535a...28e4885.html" title="Last updated on Jul 11, 2019, 5:45 AM UTC (28e4885)">Diff</a>