### PR TITLE
Add dictionary default value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -189,7 +189,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<div id="clipboardevent-idl">
 
 		<pre class="idl" data-highlight="webidl">
-		[Constructor(DOMString type, optional ClipboardEventInit eventInitDict), Exposed=Window]
+		[Constructor(DOMString type, optional ClipboardEventInit eventInitDict = {}), Exposed=Window]
 		interface ClipboardEvent : Event {
 		  readonly attribute DataTransfer? clipboardData;
 		};
@@ -596,11 +596,11 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		callback ClipboardItemDelayedCallback = ClipboardItemData ();
 
 		[Constructor(record&lt;DOMString, ClipboardItemData> items,
-		    optional ClipboardItemOptions options),
+		    optional ClipboardItemOptions options = {}),
 		 Exposed=Window] interface ClipboardItem {
 		  static ClipboardItem createDelayed(
 		      record&lt;DOMString, ClipboardItemDelayedCallback> items,
-		      optional ClipboardItemOptions options);
+		      optional ClipboardItemOptions options = {});
 
 		  readonly attribute PresentationStyle presentationStyle;
 		  readonly attribute long long lastModified;


### PR DESCRIPTION
Required after heycam/webidl#750. (Found from web-platform-tests/wpt#18382)

For *normative* changes, the following tasks have been completed:

 * [X] Modified Web platform tests  - IDL changes will be picked up automatically. 

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [X] [Gecko](https://bugs.chromium.org/p/chromium/issues/detail?id=948139) 

The following bug needs to be fixed in Blink first:
https://bugs.chromium.org/p/chromium/issues/detail?id=948139


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/clipboard-apis/pull/95.html" title="Last updated on Aug 21, 2019, 2:03 PM UTC (44d6481)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/95/fed535a...saschanaz:44d6481.html" title="Last updated on Aug 21, 2019, 2:03 PM UTC (44d6481)">Diff</a>