### PR TITLE
Editorial: Remove redefinition of `editing host`. Link mentions of it to its HTML spec definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1672,7 +1672,7 @@ access to this API is controlled by a permission.</p>
 		to occur in the underlying browser to ensure that the clipboard content is set
 		correctly (with any metadata added by the browser during copy).</p>
    <h2 class="heading settled" data-level="3" id="terminolofy"><span class="secno">3. </span><span class="content">Terminology</span><a class="self-link" href="#terminolofy"></a></h2>
-   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="editable-context">editable context</dfn> means any element that is either an <a data-link-type="dfn" href="http://w3c.github.io/editing/contentEditable.html#dfn-editing-host" id="ref-for-dfn-editing-host">editing host</a>, a textarea element, or an input element with its type
+   <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="editable-context">editable context</dfn> means any element that is either an [=editing host=], a textarea element, or an input element with its type
 	attribute set to any of "text", "search", "tel",
 	"url", "email", "password" or "number".</p>
    <h2 class="heading settled" data-level="4" id="model"><span class="secno">4. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>

--- a/tests.html
+++ b/tests.html
@@ -167,10 +167,6 @@ could also be placed in the clipboard with the appropriate transformation occurr
 <li><dfn><a href="https://www.w3.org/TR/dom/#constructing-events">construct events</a></dfn></li>
 <li><dfn><a href="https://www.w3.org/TR/dom/#eventinit">EventInit</a></dfn></li>
 </ul>
-<p>The following items are defined in the HTML Editing APIs specification [[!HTMLEA]]</p>
-<ul>
-<li><dfn><a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#editing-host">editing host</a></dfn></li>
-</ul>
 </section>
 
 <section>

--- a/tests.html
+++ b/tests.html
@@ -175,7 +175,7 @@ could also be placed in the clipboard with the appropriate transformation occurr
 
 <section>
 <h3>Terminology</h3>
-<p>The term <dfn>editable context</dfn> means any element that is either an <a>editing host</a>, a textarea element, or an input element with its type attribute set to any of <var>text</var>, <var>search</var>, <var>tel</var>, <var>url</var>, <var>email</var>, <var>password</var> or <var>number</var>.</p>
+<p>The term <dfn>editable context</dfn> means any element that is either an <a data-cite="html">editing host</a>, a textarea element, or an input element with its type attribute set to any of <var>text</var>, <var>search</var>, <var>tel</var>, <var>url</var>, <var>email</var>, <var>password</var> or <var>number</var>.</p>
 </section>
 
 <section>


### PR DESCRIPTION
Hi! I recently [imported](https://github.com/whatwg/html/pull/5253/) the definition of `editing host` from the execCommand spec to the HTML spec.

@marcoscaceres mentioned that the next steps are to find other specs that currently use `editing host` and to do the following:
1. remove any redefinitions
2. link the singular and plural forms of `editing host` to the [current definition in the HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#editing-host).

In this PR, I have :
1. removed a redefinition of `editing host` that links to https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#editing-host
2. linked `editing host` to the current definition in the HTML spec.

Similar PRs related to the `editing host` import:
* [PR 108 - Input Events](https://github.com/w3c/input-events/pull/108)
* [PR 119 - Selection API](https://github.com/w3c/selection-api/pull/119)

Thank you!