### PR TITLE
Chore: Add tidyconfig to spec

### DIFF
--- a/tidyconfig.txt
+++ b/tidyconfig.txt
@@ -1,0 +1,6 @@
+char-encoding: utf8
+indent: yes
+wrap: 80
+tidy-mark: no
+newline: LF
+custom-tags: yes


### PR DESCRIPTION
Hi! While working on [this PR](https://github.com/w3c/clipboard-apis/pull/109), I noticed that there is no `tidyconfig.txt` 

I used the tidyconfig from the [Payment Request spec](https://github.com/w3c/payment-request/blob/gh-pages/tidyconfig.txt).

cc @marcoscaceres 