### PR TITLE
Update `clipboard.write()` example to use a `ClipboardItem` list.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -714,11 +714,11 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			<div></div>
 
 			<pre class="example javascript">
-				var data = new Blob(["Text data"], {type : "text/plain"});
+				var data = [new ClipboardItem({ "text/plain": new Blob(["Text data"], { type: "text/plain" }) })];
 				navigator.clipboard.write(data).then(function() {
-					console.log(“Copied to clipboard successfully!”);
+					console.log("Copied to clipboard successfully!");
 				}, function() {
-					console.error(“Unable to write to clipboard. :-(”);
+					console.error("Unable to write to clipboard. :-(");
 				});
 			</pre>
 

--- a/index.html
+++ b/index.html
@@ -2150,11 +2150,11 @@ const text = await (new Response(textBlob)).text();
        <p>Return <var>p</var>.</p>
      </ol>
      <div></div>
-<pre class="example javascript" id="example-57aa8a1b"><a class="self-link" href="#example-57aa8a1b"></a>var data = new Blob(["Text data"], {type : "text/plain"});
+<pre class="example javascript" id="example-57aa8a1b"><a class="self-link" href="#example-57aa8a1b"></a>var data = [new ClipboardItem({ "text/plain": new Blob(["Text data"], { type: "text/plain" }) })];
 navigator.clipboard.write(data).then(function() {
-  console.log(“Copied to clipboard successfully!”);
+  console.log("Copied to clipboard successfully!");
 }, function() {
-  console.error(“Unable to write to clipboard. :-(”);
+  console.error("Unable to write to clipboard. :-(");
 });
 </pre>
     </div>


### PR DESCRIPTION
The current example doesn't match the specification (taking an array of `ClipboardItem`s), and doesn't work in e.g. Chrome.

I've updated it so that it matches the spec, which makes it work in Chrome.
(I've also fixed some smart quotes so this works correctly if it's copied and pasted.)

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgarron/clipboard-apis/pull/111.html" title="Last updated on Feb 28, 2020, 9:36 PM UTC (580a0eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/111/897bbff...lgarron:580a0eb.html" title="Last updated on Feb 28, 2020, 9:36 PM UTC (580a0eb)">Diff</a>