### PR TITLE
Update the previous version

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5,7 +5,7 @@ Shortname: clipboard-apis
 Level: none
 Group: webapps
 Status: w3c/ED
-Previous Version: https://www.w3.org/TR/2019/WD-clipboard-apis-20190530/
+Previous Version: https://www.w3.org/TR/2019/WD-clipboard-apis-20190605/
 TR: https://www.w3.org/TR/clipboard-apis/
 ED: https://w3c.github.io/clipboard-apis/
 Repository: w3c/clipboard-apis


### PR DESCRIPTION
Closes https://github.com/w3c/webappswg/issues/34

The following tasks have been completed:

 * [x ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x ] Modified Web platform tests (link to pull request)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 403 Forbidden :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 3, 2020, 6:25 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fclipboard-apis%2Fpull%2F118%2F850b84d.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fclipboard-apis%2Fpull%2F118.html)

```

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US">
<head><title>HTML Diff service</title>
<link rel="stylesheet" href="http://www.w3.org/StyleSheets/base" />
</head>
<body>

<p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C"/></a> <a href="http://www.w3.org/2003/Editors">W3C Editors homepage</a></p>

<h1>Create Diff between HTML pages</h1>

<p style='color:#FF0000'>An error (403 Forbidden) occured trying to get <a href='https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/118/850b84d.html'>https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/118/850b84d.html</a>.</p>

<form method="GET">
<p>Address of reference document: <input name="doc1" type="url" value="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/118/850b84d.html" style="width:100%"/></p>
<p>Address of new document: <input name="doc2" value="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/118.html"  style="width:100%"/></p>
<p><input type="submit" value="get Diff"/></p>
</form>

<p><strong>Tip</strong>: if the document uses the W3C convention on linking to its previous version, you can specify only the address of the new document — the previous link will be automatically detected.</p>
<h2>Diff markings</h2>
<p>This service relies on <a href="https://www.gnu.org/software/diffutils/">GNU diff</a>. The found differences are roughly marked as follow:
<ul>
<li>deleted text is shown in pink with down-arrows (as styled for a &lt;del> element)</li>
<li>where there is replacement, it’s shown in green with bi-directional arrows,</li>
<li>where there is newly inserted text, it’s yellow with up arrows (&lt;ins> element)</li>
</ul>
<address>
script $Revision$ of $Date$<br />
by <a href="http://www.w3.org/People/Dom/">Dominique Hazaël-Massieux</a><br />based on <a href="https://github.com/w3c/htmldiff-ui/blob/master/htmldiff.pl">Shane McCarron’ Perl script</a> wrapped in a <a href="https://github.com/w3c/htmldiff-ui/blob/master/htmldiff">Python CGI</a>
</address>
</body>
</html>


```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/clipboard-apis%23118.)._
</details>
