### PR TITLE
Change the ClipboardItem constructor to `ClipboardItemData`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -595,7 +595,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		callback ClipboardItemDelayedCallback = ClipboardItemData ();
 
 		[Exposed=Window] interface ClipboardItem {
-		  constructor(record&lt;DOMString, ClipboardItemData> items,
+		  constructor(record&lt;DOMString, ClipboardItemDataType> items,
 		    optional ClipboardItemOptions options = {});
 		  static ClipboardItem createDelayed(
 		      record&lt;DOMString, ClipboardItemDelayedCallback> items,


### PR DESCRIPTION
Right now:

- `ClipboardItemDataType` is a `string` or a `Blob`;
- `ClipboardItemData` is a *Promise* of a `ClipboardItemDataType`.

There are definitely some compatibility issues in the wild. In particular, Chrome only accepts `Blob`s, and throws an exception if you pass in a string or a Promise. Is it possible that the constructor is supposed to take `ClipboardItemDataType` values? If not, should it accept any values that are either `ClipboardItemDataType` *or* `ClipboardItemDataType`?