### PR TITLE
Remove clipboard-read permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -935,8 +935,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	<a>powerful feature</a>s like the clipboard. It allows websites to request permissions
 	from users and query which permissions they have.
 
-	For the clipboard, two separate permissions are defined:
-	<dfn enum-value for="PermissionName">"clipboard-read"</dfn> and
+	For the clipboard, one permission is defined:
 	<dfn enum-value for="PermissionName">"clipboard-write"</dfn>
 
 	Note: Clipboard permissions currently only apply to the Async Clipboard API.
@@ -960,52 +959,23 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 	There are 4 clipboard permissions:
 
-	* { name: "clipboard-read", allowWithoutGesture: false }
-	* { name: "clipboard-read", allowWithoutGesture: true }
 	* { name: "clipboard-write", allowWithoutGesture: false }
 	* { name: "clipboard-write", allowWithoutGesture: true }
 
 	With the following relationships:
 
-	* <code>{ "clipboard-read" + true }</code> is stronger than <code>{ "clipboard-read" + false }</code>
 	* <code>{ "clipboard-write" + true }</code> is stronger than <code>{ "clipboard-write" + false }</code>
-
-	Note: "clipboard-read" and "clipboard-write" are two separate permissions with no
-	inherent strength relationship. However, user agents MAY choose to impose such a
-	strength ordering on these permissions, for example by making the "clipboard-read"
-	permission act stronger than the "clipboard-write" permission. Doing this would
-	effectively turn the "clipboad-read" permission into a way to provide full
-	read/write access to the clipboard since granting (or denying) "clipboard-read" would
-	also grant (deny) "clipboard-write" access.
 
 	While user agents MUST support the {{ClipboardPermissionDescriptor}} as described
 	in this specification, they, of course, retain complete control over the default
 	settings and how (or if) they are exposed to the user.
 
 	<div class="example">
-		A user agent that wants to have separate user-settable read and write controls over the clipboad
+		A user agent that wants to have separate user-settable write controls over the clipboard
 		and always require a user gesture would handle each descriptor as follows:
 
-		* <code class="perm">{ "clipboard-read" + false }</code> is exposed for user control
-		* <code class="perm">{ "clipboard-read" + true }</code> is always <a>denied</a>
 		* <code class="perm">{ "clipboard-write" + false }</code> is exposed for user control
 		* <code class="perm">{ "clipboard-write" + true }</code> is always <a>denied</a>
-	</div>
-
-	<div class="example">
-		A user agent that wants to automatically grant "write" access (with a gesture),
-		but have a single user-settable permission that controls full gesture-less access would
-		define "clipboard-read" as being stronger than "clipboard-write" and then handle
-		each descriptor as follows:
-
-		* <code class="perm">{ "clipboard-read" + false }</code> is inherited from
-			<code class="perm">{ "clipboard-read" + true }</code>
-		* <code class="perm">{ "clipboard-read" + true }</code> is exposed for user control
-		* <code class="perm">{ "clipboard-write" + false }</code> is inherited from
-			<code class="perm">{ "clipboard-write" + true }</code>
-		* <code class="perm">{ "clipboard-write" + true }</code> is <a>granted</a> by default, but
-			may be overridden by <code class="perm">{ "clipboard-read" + true }</code> because
-			"read" is stronger than "write".
 	</div>
 
 	<h3 id="read-permission">Clipboard read permission</h3>
@@ -1013,34 +983,17 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<div class="algorithm" data-algorithm="clipboard-read-permission">
 		<h4 id="h-clipboard-read-permission"><dfn>check clipboard read permission</dfn></h4>
 
-		1. Let |readWithoutGesture| be the [=permission state=] of the
-			<code>{ name: "clipboard-read", allowWithoutGesture: true }</code>
-			permission.
-
-		1. If |readWithoutGesture| is <a>granted</a>, then return true.
-
 		1. Let |hasGesture| be true if the [=relevant global object=] of [=this=] has
 		    [=transient activation=], false otherwise.
 
 		1. If |hasGesture| then,
 
 			<!-- System paste buttons don't require permission -->
-			1. Let |systemPaste| be true if the current script is running as a result of user
+			1. Return true if the current script is running as a result of user
 				interaction with a "Paste" element created by the user agent or operating
 				system.
 
-			1. If |systemPaste| is true, then return true.
-
-			1. Return the result of [=request permission to use=] the
-				<code>{ name: "clipboard-read", allowWithoutGesture: false }</code>
-				permission.
-
-				Note: User agents may choose to request a stronger permission that
-				will implicitly update this permission.
-
-		1. Return the result of [=request permission to use=] the
-			<code>{ name: "clipboard-read", allowWithoutGesture: true }</code>
-			permission.
+		1. Return false.
 
 		</div><!-- algorithm -->
 


### PR DESCRIPTION
Closes #101, see also https://github.com/w3c/permissions/issues/175

For normative changes, the following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [x] WebKit - Never shipped, and doesn't support this change.
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [x] Gecko - Never shipped, and doesn't support this change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/132.html" title="Last updated on Oct 26, 2020, 5:05 AM UTC (1084f2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/132/4231c62...1084f2e.html" title="Last updated on Oct 26, 2020, 5:05 AM UTC (1084f2e)">Diff</a>