### PR TITLE
Add link-default for HTML's Navigator interface.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,6 +32,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/interaction.html#; type: dfn;
 	text: dom anchor
 url: https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2; type: dfn;
 	text: the body element
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/system-state.html; type: interface;
+	text: Navigator
 urlPrefix: http://www.w3.org/TR/html5/browsers.html#; type: dfn;
 	text: allowed to show a popup
 urlPrefix: https://dom.spec.whatwg.org/#; type: dfn;


### PR DESCRIPTION
Closes #146


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mfalken/clipboard-apis/pull/147.html" title="Last updated on May 23, 2021, 8:20 AM UTC (4515668)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/147/5b75462...mfalken:4515668.html" title="Last updated on May 23, 2021, 8:20 AM UTC (4515668)">Diff</a>