### PR TITLE
Add mandatory and optional data types list.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -528,19 +528,17 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			corresponding native type exists on the clipboard:
 
 			* text/plain
-			* text/uri-list
-			* text/csv
-			* text/css
 			* text/html
-			* application/xhtml+xml
 			* image/png
+
+			These data types may be exposed by <em>paste</em> events if a
+			corresponding native type exists on the clipboard:
+
+			* text/uri-list
 			* image/jpg, image/jpeg
 			* image/gif
 			* image/svg+xml
-			* application/xml, text/xml
-			* application/javascript
-			* application/json
-			* application/octet-stream
+			* text/rtf
 
 		<h4 id="writing-to-clipboard">Writing to the clipboard</h4>
 
@@ -549,12 +547,18 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			<em>copy</em> and <em>cut</em> events.
 
 			* text/plain
-			* text/uri-list
-			* text/csv
 			* text/html
+			* image/png
+
+			These data types may be placed on the clipboard with a corresponding
+			native type description if added to a {{DataTransfer}} object during
+			<em>copy</em> and <em>cut</em> events.
+
+			* text/uri-list
+			* image/jpg, image/jpeg
+			* image/gif
 			* image/svg+xml
-			* application/xml, text/xml
-			* application/json
+			* text/rtf
 
 			Advisement: Warning! The data types that untrusted scripts are allowed to write to the
 			clipboard are limited as a security precaution. Untrusted scripts can


### PR DESCRIPTION
Closes https://github.com/w3c/editing/issues/305

For normative changes, the following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * Already implemented by WebKit, Chromium & Gecko.
 
