### PR TITLE
Add explicit language around (not) sanitizing images.

### DIFF
--- a/explainer.adoc
+++ b/explainer.adoc
@@ -258,9 +258,9 @@ Clipboard API will not affect the operation of the existing clipboard APIs.
 There are a few avenues for abuse that are not specific to the Async API,
 but are applicable to any API that provides clipboard access.
 
-It is one of these abuse vectors in particular, pasting images, that motivated
+It is one of these abuse vectors in particular, copying images, that motivated
 the creation of the Async Clipboard API. In order to clean up malicious images,
-they would need to be decoded and it is not appropriate to do this on
+they would need to be transcoded and it is not appropriate to do this on
 the main thread (large images could lock the browser while the image is
 being processed).
 
@@ -291,10 +291,9 @@ script (link:https://en.wikipedia.org/wiki/Self-XSS[Self-XSS]).
 
 ==== Pasting Images
 
-Images can be crafted to exploit bugs in the image-handling code, so they
-need to be scrubbed as well. Transcoding large images can be computationally
-expensive, so care must be taken to avoid processing them on the main thread.
-
+Images can be crafted to exploit bugs in the image-handling code. However many
+other ways exist to get untrusted images in web content, so little would be gained
+from transcoding images when they are pasted into a website.
 
 === Mitigating Abuse
 

--- a/index.bs
+++ b/index.bs
@@ -637,6 +637,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. Let |data| be a copy of the [=system clipboard data=] represented as
 					a sequence of {{ClipboardItem}}s.
+					
+					Note: As further described in [[#image-transcode]] this explicitly does not transcode images.
+					Rather the original unmodified image data should be exposed to the website.
 
 				1. Resolve |p| with |data|.
 
@@ -1121,7 +1124,14 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	<h3 id="image-transcode">Transcoding images</h3>
 
 		To prevent malicious image data from being placed on the clipboard, the image
-		data may be transcoded to produce a safe version of the image.
+		data may be transcoded to produce a safe version of the image. This prevents websites
+		from trying to exploit security vulnerabilities in other applications.
+
+		Implementations should not transcode images being read from the clipboard.
+		Transcoding images can lose important metadata (such as the physical resolution
+		of an image).
+		This is also consistent with other methods in which images can be shared
+		with a website (such as `&lt;input type=file&gt;`).
 
 	<h3 id="nuisances">Nuisance considerations</h3>
 


### PR DESCRIPTION
Images are only sanitized when writing to the clipboard, not when
reading them back. This is consistent with the Firefox and Safari
implementations, while Chrome also plans to match this behavior.

This is merely clarifying spec language. Before the spec was silent on
transcoding images on read, while now we make it explicit that not
transcoding should be done.

For normative changes, the following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [x] WebKit (matches current behavior)
 * [x] Chromium (https://chromestatus.com/feature/5629962485760000)
 * [x] Gecko (matches current behavior)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mkruisselbrink/clipboard-apis/pull/156.html" title="Last updated on Sep 7, 2021, 9:09 PM UTC (669d8b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/156/71c9405...mkruisselbrink:669d8b7.html" title="Last updated on Sep 7, 2021, 9:09 PM UTC (669d8b7)">Diff</a>