### PR TITLE
Add Custom Clipboard format support to async clipboard.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -168,7 +168,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		exposed as a {{DataTransfer}} object that mirrors the contents of the clipboard.
 
 	* For the [[#async-clipboard-api]], the [=system clipboard data=] is
-		exposed as a sequence of {{ClipboardItem}} objects that mirrors the contents of
+		exposed as a sequence of [=ClipboardItem=] objects that mirrors the contents of
 		the clipboard.
 
 <h2 id="clipboard-events-and-interfaces">Clipboard Events</h2>
@@ -577,10 +577,113 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<div class="algorithm" data-algorithm="navigator-clipboard">
 		<h4 id="h-navigator-clipboard"><dfn>clipboard</dfn></h4>
 		The [=clipboard=] attribute must return the {{Navigator}}'s [=clipboard=] object.
-		It is used to execute read/write operation from/to the [=system clipboard=].
+		It is used to execute read/write operations from/to the [=system clipboard=].
 		</div>
 
 		</div><!-- dfn-for Navigator -->
+
+	<h3 id="clipboard-item-interface">ClipboardItem Interface</h3>
+		<pre class="idl" data-highlight="webidl">
+			typedef (DOMString or Blob) ClipboardItemDataType;
+			typedef Promise&lt;ClipboardItemDataType> ClipboardItemData;
+
+			callback ClipboardItemDelayedCallback = ClipboardItemData ();
+
+			[SecureContext, Exposed=Window] interface ClipboardItem {
+			constructor(record&lt;DOMString, ClipboardItemData> items,
+				optional ClipboardItemOptions options = {});
+			static ClipboardItem createDelayed(
+				record&lt;DOMString, ClipboardItemDelayedCallback> items,
+				optional ClipboardItemOptions options = {});
+
+			readonly attribute PresentationStyle presentationStyle;
+			readonly attribute long long lastModified;
+			readonly attribute boolean delayed;
+
+			readonly attribute FrozenArray&lt;DOMString> types;
+
+			Promise&lt;Blob> getType(DOMString type);
+			};
+
+			enum PresentationStyle { "unspecified", "inline", "attachment" };
+
+			dictionary ClipboardItemOptions {
+			PresentationStyle presentationStyle = "unspecified";
+			};
+		</pre>
+		<p><dfn export for=ClipboardItem id=concept-clipboard-item>ClipboardItem</dfn></p>
+		The [=ClipboardItem=] object has MIME types that are in the {{ClipboardItem/types}} list, and [=Blob=]s corresponding to the {{ClipboardItem/types}}.
+		It has a mapping of the MIME types in {{DOMString}} format and a [=Blob=] corresponding to the MIME types that contains the actual payload.
+		There can be multiple [=ClipboardItem=]s as each [=ClipboardItem=] represents contents of a clipboard, and there can be multiple clipboards supported on a platform such as iOS/iPadOS.
+		A web author needs to create a |data| which is a [=ClipboardItems=] object in order to write content to multiple clipboards using the {{Clipboard/write(data)}} method. {{Clipboard/read()}} returns a [=Promise=] to [=ClipboardItems=] object
+		that represents contents of multiple clipboards. A [=ClipboardItem=] can be read from [=ClipboardItems=], which then can be used to read a specific |type| using {{ClipboardItem/getType(type)}}.
+		<dl class=note>
+			<dt><code><var>clipboardItem</var> = new ClipboardItem([<var>items</var>, <var>options</var>])</code>
+			<dd>
+			Creates a new [=ClipboardItem=] object. <var>items</var> are used to fill its MIME types and [=Promise=]s to [=Blob=]s corresponding to the MIME types, <var>options</var> can be used to fill its {{ClipboardItemOptions}},
+			as per the example below.
+
+			<pre class="example javascript">
+			const format1 = 'text/plain';
+			const promise_text_blob = Promise.resolve(new Blob(['hello'], {type: format1}));
+			const clipboardItemInput = new ClipboardItem(
+				{[format1]: promise_text_blob},
+				{options: "unspecified"});
+			</pre>
+
+			<dt><code><var>clipboardItem</var>.getType(<var>type</var>)</code>
+			<dd><p>Returns a  [=Promise=] to the [=Blob=] corresponding to the <var>type</var>.</p>
+
+			<dt><code><var>clipboardItem</var>.<var>types</var></code>
+			<dd><p>Returns the list of <var>types</var> contained in the <var>clipboardItem</var> object.
+
+		</dl>
+		<p>
+			The <a constructor lt="ClipboardItem()">ClipboardItem</a> step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code> is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
+		</p>
+
+		Issue: Add definition to clarify what {{ClipboardItem/createDelayed()}} method does. From the discussions it looks like a Windows/Mac only feature where the
+		platform supports writing of the data to the system clipboard in a delayed fashion so the system clipboard can request data on-demand.
+		See https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations#delayed-rendering
+
+		<h4 attribute for=ClipboardItem lt=presentationStyle>presentationStyle</h4>
+		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.
+		
+		Note: {{ClipboardItem/presentationStyle}} helps distinguish between "inline" data(e.g. selecting text on a web page and copying), vs. file-like data (e.g. copying a plain text file).
+				  This difference is used to provide a hint when writing to the system pasteboard on iOS/iPadOS. This allows apps like Notes to insert a file attachment when copying a plain text file from the Files app, but insert text inline when
+				  copying a selected piece of plain text from another app. In both cases, the MIME type in the pasteboard would be text/plain. This is used for both reading and writing.
+		</p>
+
+		<p>{{ClipboardItem/presentationStyle}} getter steps are to return [=this=]'s {{ClipboardItem/presentationStyle}}</p>
+
+		Issue: Currently {{ClipboardItem/lastModified}} is not supported in Chromium and Safari, Should we remove it?
+
+		Issue: Delay rendering support has not been added to Chromium and Safari so {{ClipboardItem/delayed}} is unused.
+
+		<h4 attribute for=ClipboardItem lt=types>types</h4>
+		<p> Returns the MIME types used to create the [=ClipboardItem=] object.</p>
+		<p>{{ClipboardItem/types}} getter steps are to return [=this=]'s {{ClipboardItem/types}}</p>
+
+		<h4 method for=ClipboardItem lt=getType(type)>getType(type)</a> must run the below steps:</h4>
+
+			1. Let |p| be a new [=Promise=].
+
+			1. If |type| is not listed in the [=mandatory data types=] list, then reject |p| with a "The type was not found" DOMException.
+
+			1. Let |data| be the result of reading the |type| from the [=system clipboard=].
+
+			1. Let |blobData| be the |data| represented as a [=Blob=].
+
+			1. Resolve |p| with |blobData|.
+
+		<h4 typedef>ClipboardItemDataType</h4>
+		<p>
+		 	It is a {{DOMString}} or [=Blob=] type. This contains the payload corresponding to the MIME type while creating a [=ClipboardItem=] object.
+		</p>
+		<h4 typedef>ClipboardItemData</h4>
+		<p>
+			It is a [=Promise=] to the {{ClipboardItemDataType}}.
+		</p>
 
 	<h3 id="clipboard-interface">Clipboard Interface</h3>
 
@@ -593,111 +696,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		  Promise&lt;undefined> write(ClipboardItems data);
 		  Promise&lt;undefined> writeText(DOMString data);
 		};
-
-		typedef (DOMString or Blob) ClipboardItemDataType;
-		typedef Promise&lt;ClipboardItemDataType> ClipboardItemData;
-
-		callback ClipboardItemDelayedCallback = ClipboardItemData ();
-
-		[Exposed=Window] interface ClipboardItem {
-		  constructor(record&lt;DOMString, ClipboardItemData> items,
-		    optional ClipboardItemOptions options = {});
-		  static ClipboardItem createDelayed(
-		      record&lt;DOMString, ClipboardItemDelayedCallback> items,
-		      optional ClipboardItemOptions options = {});
-
-		  readonly attribute PresentationStyle presentationStyle;
-		  readonly attribute long long lastModified;
-		  readonly attribute boolean delayed;
-
-		  readonly attribute FrozenArray&lt;DOMString> types;
-
-		  Promise&lt;Blob> getType(DOMString type);
-		};
-
-		enum PresentationStyle { "unspecified", "inline", "attachment" };
-
-		dictionary ClipboardItemOptions {
-		  PresentationStyle presentationStyle = "unspecified";
-		};
 		</pre>
 
-		<div class="algorithm" data-algorithm="clipboard-item">
-		<h4 id="h-clipboard-item"><dfn>ClipboardItem</dfn></h4>
-		The [=ClipboardItem=] object represents the content of the MIME types that are in the [=mandatory data types=] list, and are currently on the [=system clipboard=].
-		It has a mapping of the MIME types in {{DOMString}} format and a [=Blob=] corresponding to the MIME types that contains the actual payload. A web author needs to
-		create a [=ClipboardItem=] object in order to write content to the clipboard using the {{Clipboard/write()}} method. {{Clipboard/read()}} returns a [=ClipboardItem=] object
-		that can be used to read a specific |type| using {{ClipboardItem/getType()}}.
-		</div>
-		<dl class=note>
-			<dt><code><var>clipboardItem</var> = new <a constructor lt="ClipboardItem()">ClipboardItem</a>([<var>items</var>, <var>options</var>])</code>
-			<dd>
-			Creates a new {{ClipboardItem}} object. <var>items</var> are used to fill its MIME types and [=Promise=]s to [=Blob=]s corresponding to the MIME types, <var>options</var> can be used to fill its {{ClipboardItemOptions}},
-			as per the example below.
-
-			<div class=example id=example-clipboard-item-class>
-			<pre><code class=lang-javascript>
-			const format1 = 'text/plain';
-			const promise_text_blob = Promise.resolve(new Blob(['hello'], {type: format1}));
-			const clipboardItemInput = new ClipboardItem(
-				{[format1]: promise_text_blob},
-				{options: "unspecified"});
-			</code></pre>
-			</div>
-
-			<dt><code><var>clipboardItem</var> . <a method for=ClipboardItem lt=getType()>getType</a>(<var>type</var>)</code>
-			<dd><p>Returns a  [=Promise=] to the [=Blob=] corresponding to the <var>type</var>.</p>
-
-			<dt><code><var>types</var> of <var>clipboardItem</var></code>
-			<dd><p>Returns the list of <var>types</var> contained in the <var>clipboardItem</var> object.
-
-		</dl>
-		<p>
-			The {{ClipboardItem/constructor()}} step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code> is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
-		</p>
-
-		<dfn>ClipboardItemDataType</dfn>
-		<p>
-			A {{DOMString}} or [=Blob=] type. This contains the payload corresponding to the MIME type while creating a {{ClipboardItem}} object.
-		</p>
-
-		<dfn>ClipboardItemData</dfn>
-		<p>
-			A [=Promise=] to the [=ClipboardItemDataType=].
-		</p>
-
-		{{ClipboardItem}}
-		<p> A {{ClipboardItem}} object contains the {{ClipboardItem/types}} listed in the [=mandatory data types=] list that are present on the [=system clipboard=].
-		<p> The {{ClipboardItem/constructor()}} step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code>
-		is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
-		</p>
-
-		Issue: Add definition to clarify what {{ClipboardItem/createDelayed()}} method does. From the discussions it looks like a Windows/Mac only feature where the
-		platform supports writing of the data to the system clipboard in a delayed fashion so the system clipboard can request data on-demand.
-		See https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations#delayed-rendering
-
-		<dfn>presentationStyle</dfn>
-		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.</p>
-
-		<p>{{ClipboardItem/presentationStyle}} getter steps are to return [=this=]'s {{ClipboardItem/presentationStyle}}</p>
-
-		Issue: Currently {{ClipboardItem/lastModified}} is not supported in Chromium and Safari, Should we remove it?
-
-		Issue: Delay rendering support has not been added to Chromium and Safari so {{ClipboardItem/delayed}} is unused.
-
-		<dfn>types</dfn>
-		<p> Returns {{ClipboardItem/types}} listed in the [=mandatory data types=] list that are present on the [=system clipboard=].
-
-		<dfn>getType({{DOMString}} type)</dfn>
-		<p> The {{ClipboardItem/getType()}} must run the below steps:</p>
-
-			1. Let |p| be a new [=Promise=].
-
-			1. If |type| is not listed in the [=mandatory data types=] list, then reject |p| with a "The type was not found" DOMException.
-
-			1. Let |data| be the result of reading the |type| from the [=system clipboard=].
-
-			1. Resolve |p| with |data|.
+		<h4 typedef>ClipboardItems</h4>
+		<p>A sequence of [=ClipboardItem=] objects</p>
 
 		<div id="clipboard-idl" dfn-for="Clipboard">
 		<div class="algorithm" data-algorithm="clipboard-read">
@@ -715,11 +717,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
-				1. Let |data| be a copy of the [=system clipboard data=] represented as
-					a sequence of {{ClipboardItem}}s. For the MIME types defined in the [=mandatory data types=] list,
-					|data| contains the sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
+				1. Let |data| be a copy of the [=system clipboard data=] represented as [=ClipboardItems=]. For the MIME types defined in the [=mandatory data types=] list, |data| contains the sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
 
-					Note: Currently in Chromium, only a single {{ClipboardItem}} object is supported for reading and writing via [=clipboard=] object.
+					Note: Currently in Chromium, only one [=ClipboardItem=] object is supported for reading and writing via [=clipboard=] object.
 					
 					Note: As further described in [[#image-transcode]] this explicitly does not transcode images.
 					Rather the original unmodified image data should be exposed to the website.
@@ -786,24 +786,26 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. Let |itemList| and |cleanItemList| be an empty sequence&lt;{{Blob}}>.
 
-				1. For each |item| in |data|:
-					1. If [=Promise=] to {{Blob}} in |item| is rejected, then throw "Promises to Blobs were rejected." DOMException.
+				1. For each |itemData| in |data|:
 
-					1. Add the {{Blob}} in |item| to |itemList| after the promise has been resolved.
+					1. For each |item| in |itemData|:
+						1. If [=Promise=] to {{Blob}} in |item| is rejected, then throw "Promises to Blobs were rejected." DOMException.
 
-				1. For each {{Blob}} |itemBlob| in |itemList|:
+						1. Add the {{Blob}} in |item| to |itemList| after the promise has been resolved.
 
-					1. If {{Blob/type}} is not in the [=mandatory data types=] list, then reject |p| with a "Type {{Blob/type}} not supported on write." DOMException.
+					1. For each {{Blob}} |itemBlob| in |itemList|:
 
-					1. Let |cleanItem| be a sanitized copy of |itemBlob|.
+						1. If {{Blob/type}} is not in the [=mandatory data types=] list, then reject |p| with a "Type {{Blob/type}} not supported on write." DOMException.
 
-						Issue: Add definition of sanitized copy.
+						1. Let |cleanItem| be a sanitized copy of |itemBlob|.
 
-					1. If unable to create a sanitized copy, then reject |p|.
+							Issue: Add definition of sanitized copy.
 
-					1. Add |cleanItem| to |cleanItemList|.
+						1. If unable to create a sanitized copy, then reject |p|.
 
-				1. Replace the [=system clipboard data=] with |cleanItemList|.
+						1. Add |cleanItem| to |cleanItemList|.
+
+					1. Replace the [=system clipboard data=] with |cleanItemList|.
 
 				1. Resolve |p|.
 
@@ -834,13 +836,13 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
-				1. Let |newItemList| be an empty sequence&lt;{{ClipboardItem}}>.
+				1. Let |newItemList| be empty [=ClipboardItems=].
 
 				1. Let |textBlob| be a new {{Blob}} created with:
 					[=type=] attribute set to <em>text/plain;charset=utf-8</em>, and
 					[=blobParts=] set to a sequence containing the <em>string</em> |data|.
 
-				1. Let |newItem| be a new {{ClipboardItem}} created with a single
+				1. Let |newItem| be a new [=ClipboardItem=] created with a single
 					representation:
 					[=type=] attribute set to <em>text/plain8</em>, and
 					[=data=] set to |textBlob|.

--- a/index.bs
+++ b/index.bs
@@ -603,6 +603,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 			dictionary ClipboardItemOptions {
 			PresentationStyle presentationStyle = "unspecified";
+			sequence&lt;DOMString&gt; unsanitized;
 			};
 		</pre>
 		<p><dfn export for=ClipboardItem id=concept-clipboard-item>ClipboardItem</dfn></p>
@@ -646,14 +647,6 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			The <a constructor lt="ClipboardItem()">ClipboardItem</a> step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code> is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
 		</p>
 
-		<h4 attribute for=ClipboardItem lt=presentationStyle>presentationStyle</h4>
-		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.
-		
-		Note: {{ClipboardItem/presentationStyle}} helps distinguish between "inline" data(e.g. selecting text on a web page and copying), vs. file-like data (e.g. copying a plain text file).
-				  This difference is used to provide a hint when writing to the system pasteboard on iOS/iPadOS. This allows apps like Notes to insert a file attachment when copying a plain text file from the Files app, but insert text inline when
-				  copying a selected piece of plain text from another app. In both cases, the MIME type in the pasteboard would be text/plain. This is used for both reading and writing.
-		</p>
-
 		<p>{{ClipboardItem/presentationStyle}} getter steps are to return [=this=]'s {{ClipboardItem/presentationStyle}}</p>
 
 		<h4 attribute for=ClipboardItem lt=types>types</h4>
@@ -683,6 +676,19 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			A [=Promise=] to a {{ClipboardItemDataType}}.
 		</p>
 
+		<h4 attribute for=ClipboardItemOptions lt=presentationStyle>presentationStyle</h4>
+		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.
+		
+		Note: {{ClipboardItemOptions/presentationStyle}} helps distinguish between "inline" data(e.g. selecting text on a web page and copying), vs. file-like data (e.g. copying a plain text file).
+				  This difference is used to provide a hint when writing to the system pasteboard on iOS/iPadOS. This allows apps like Notes to insert a file attachment when copying a plain text file from the Files app, but insert text inline when
+				  copying a selected piece of plain text from another app. In both cases, the MIME type in the pasteboard would be text/plain. This is used for both reading and writing.
+		</p>
+
+		<h4 attribute for=ClipboardItemOptions lt=unsanitized>unsanitized</h4>
+		<p>
+			 [=sequence=] of {{DOMString}} that contains the MIME types that don't go through the sanitization process during clipboard read/write operation.
+		</p>
+
 	<h3 id="clipboard-interface">Clipboard Interface</h3>
 
 		<pre class="idl" data-highlight="webidl">
@@ -702,7 +708,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		A [=ClipboardItem=] can be read from [=ClipboardItems=], which then can be used to read a specific |type| using {{ClipboardItem/getType(type)}}.
 
 		<h4 typedef>ClipboardItems</h4>
-		<p>A sequence of [=ClipboardItem=] objects</p>
+		<p>A [=sequence=] of [=ClipboardItem=] objects</p>
 
 		<div id="clipboard-idl" dfn-for="Clipboard">
 		<div class="algorithm" data-algorithm="clipboard-read">
@@ -723,12 +729,18 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. If |r| is not "granted", then [=a promise rejected with=] "NotAllowedError" DOMException in |realm|.
 
-				1. Let |data| be a copy of the [=system clipboard data=] represented as [=ClipboardItems=]. For the MIME types defined in the [=mandatory data types=] list, |data| contains the sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
+				1. Let |data| be a copy of the [=system clipboard data=] represented as [=ClipboardItems=].
+				
+				1. For the MIME types defined in the [=mandatory data types=] list, |data| contains sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
 
-					Note: Currently in Chromium, only one [=ClipboardItem=] object is supported for reading and writing via the [=clipboard=] object.
+				Note: Currently in Chromium, only one [=ClipboardItem=] object is supported for reading and writing via the [=clipboard=] object.
 					
-					Note: As further described in [[#image-transcode]] this explicitly does not transcode images.
+				Note: As further described in [[#image-transcode]] this explicitly does not transcode images.
 					Rather the original unmodified image data should be exposed to the website.
+				
+				1. For the MIME types defined in the {{ClipboardItemOptions/unsanitized}}, |data| contains copy of the unsanitized payload of the MIME types.
+
+				Note: See [=read unsanitized format=] for more details.
 
 				1. Resolve |p| with |data|.
 
@@ -740,6 +752,20 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				const items = await navigator.clipboard.read();
 				const textBlob = await items[0].getType("text/plain");
 				const text = await (new Response(textBlob)).text();
+			</pre>
+
+			<pre class="example javascript">
+				// Pickling read example. ClipboardItems returned by clipboard.read() may 
+				// contain pickled formats.
+				const clipboardItems = await navigator.clipboard.read(
+					{unsanitized: ['text/custom']} /* This new list specifies the pickled format
+											'text/custom' for all read ClipboardItems. */
+				);
+				const clipboardItem = clipboardItems[0];
+				const textBlob = await clipboardItem.getType('text/plain');
+				// This format reads as a pickled format, only if it is included in the unsanitized
+				// format list.
+				const customTextBlob = await clipboardItem.getType('text/custom');
 			</pre>
 
 		</div><!-- read() -->
@@ -802,7 +828,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. If |r| is not "granted", then [=a promise rejected with=] "NotAllowedError" DOMException in |realm|.
 
-				1. Let |itemList| and |cleanItemList| be an empty sequence&lt;{{Blob}}&gt;.
+				1. Let |itemList|, |cleanItemList| and |unsanitizedItemList| be empty sequence&lt;{{Blob}}&gt;.
+
+				1. Let |u| be the [=sequence=] of string in the {{ClipboardItemOptions/unsanitized}} list.
 
 				1. Let |clipboardItemList| be an empty [=ClipboardItems=].
 
@@ -820,19 +848,31 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 						1. Let |type| be the |blob|'s {{Blob/type}}.
 
-						1. If |type| is not in the [=mandatory data types=] list, then [=a promise rejected with=] "Type |type| not supported on write." DOMException in |realm|.
+						1. If |type| is not in the [=mandatory data types=] list:
+							
+							1. If |type| is not in |u| then throw [=a promise rejected with=] "Type |type| not supported on write." DOMException in |realm|.
 
-						1. Let |cleanItem| be a sanitized copy of |blob|.
+						1. Let |unsanitizedItem| be an unsanitized copy of |blob|.
+						
+						1. If |type| is in the [=mandatory data types=] list: 
+						
+							1. Let |cleanItem| be a sanitized copy of |blob|.
 
 							Issue: Add definition of sanitized copy.
 
-						1. If unable to create a sanitized copy, then [=reject=] |p|.
+							1. Add |cleanItem| to |cleanItemList|.
 
-						1. Add |cleanItem| to |cleanItemList|.
+							1. If unable to create a sanitized copy, then [=reject=] |p|.
+
+						1. Add |unsanitizedItem| to |unsanitizedItemList|.
 					
+					1. Add |unsanitizedItemList| to |clipboardItemList|.
+
 					1. Add |cleanItemList| to |clipboardItemList|.
 
 				1. Replace the [=system clipboard data=] with |clipboardItemList|.
+
+				Note: For writing |type| to the [=system clipboard=] that are in the {{ClipboardItemOptions/unsanitized}} list, please see [=write unsanitized format=].
 
 				Note: Writing multiple [=ClipboardItem=]s to the clipboard is only supported on MacOS.
 				For other platforms, only the first [=ClipboardItem=] should be written to the clipboard.
@@ -850,6 +890,32 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				}, function() {
 					console.error("Unable to write to clipboard. :-(");
 				});
+			</pre>
+
+			<pre class="example javascript">
+				// Pickling write example.
+				// This format 'text/plain' is recognized by the Clipboard API, so will be
+				// written as usual.
+				const text = new Blob(['text'], {type: 'text/plain'});
+				// This format 'text/custom' is not sanitized by the Clipboard API. It will be
+				// pickled if the format is specified in the {unsanitized: []} formats list.
+				const customText = new Blob(
+				['<custom_markup>pickled_text</custom_markup>'], {type: 'text/custom'});
+
+				// Clipboard format ordering: Pickled formats will be written before sanitized
+				// formats by the browser, since they're more "custom" and likely more targeted
+				// towards this use case.
+				const clipboardItem = new ClipboardItem({
+				  'text/plain': text,       /* Sanitized format. */
+				  'text/custom': customText /* Pickled format. This new format will be accepted
+											and written without rejection, as long as the new
+											unsanitized list contains this format. */
+				}, 
+				{unsanitized: ['text/custom']} /* This new list specifies the pickled format
+										'text/custom'. */
+				);
+				navigator.clipboard.write([clipboard_item]);
+
 			</pre>
 
 		</div><!-- write() -->
@@ -1713,3 +1779,115 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 
 	</div><!-- algorithm -->
+
+	<div class="algorithm" data-algorithm="read-unsanitized-format">
+	<i>This section is non-normative.</i>
+	<h3 id="to-read-unsanitized-format"><dfn>read unsanitized format</dfn></h3>
+
+		: Input
+		:: |mimeType|, a string
+
+		: Output
+		:: |item|, a {{Blob}}
+
+		1. Let |webCustomFormatMap| be the [=os specific custom map name=].
+
+		1. Read |webCustomFormatMap| from the [=system clipboard=].
+
+		1. Let |webCustomFormatMapString| be the JSON string deserialized from |webCustomFormatMap|.
+
+			Note: Need a JSON reader to deserialize the content from the |webCustomFormatMap|.
+
+		1. Let |webCustomFormat| be the value corresponding to the |mimeType| key in |webCustomFormatMapString|.
+
+		1. Let |item| be a {{Blob}}.
+
+		1. Read |webCustomFormat| from the [=system clipboard=] and store the resulting data into |item|.
+
+		1. Return |item|.
+
+	</div><!-- algorithm -->
+
+	<h3 id="to-write-unsanitized-format"><dfn>write unsanitized format</dfn></h3>
+
+		: Input
+		:: |items|, {{Blob}}s
+		:: |mimeType|, a string
+
+		1. Let |idx| be a number initialized to 0.
+
+		1. Let |webCustomFormatMap| be the [=os specific custom map name=].
+
+		1. For each |item| in |items|:
+
+			1. Let |webCustomFormat| be the [=os specific custom name=].
+
+			1. Let |webCustomFormatIdx| be the result of appending |idx| to |webCustomFormat|.
+
+			1. Insert |mimeType| as key and |webCustomFormatIdx| as value into the |webCustomFormatMap|.
+
+				Note: Need a JSON writer to serialize the content into the |webCustomFormatMap|.
+
+			1. Insert the |item| into the [=system clipboard=] using |webCustomFormatIdx| as the format.
+
+			1. Increment |idx|.
+
+		1. Insert the |webCustomFormatMap| into the [=system clipboard=].
+
+
+	</div><!-- algorithm -->
+
+	<div class="algorithm" data-algorithm="os-specific-custom-map-name">
+	<i>This section is non-normative.</i>
+	<h3 id="to-os-specific-custom-map-name"><dfn>os specific custom map name</dfn></h3>
+
+		: Output
+		:: |webCustomFormatMap|, a string
+
+		On Windows, follow the convention described below:
+
+		1. Assign "Web Custom Format Map" to |webCustomFormatMap|.
+
+		1. Return |webCustomFormatMap|.
+
+		On MacOS, follow the convention described below:
+
+		1. Assign "com.web.custom.format.map" to |webCustomFormatMap|.
+
+		1. Return |webCustomFormatMap|.
+
+		On Linux, ChromeOS, and Android, follow the convention described below:
+
+		1. Assign "application/web;type=\"custom/formatmap\"" to |webCustomFormatMap|.
+
+		1. Return |webCustomFormatMap|.
+
+	</div><!-- algorithm -->
+
+	<div class="algorithm" data-algorithm="os-specific-custom-name">
+	<i>This section is non-normative.</i>
+	<h3 id="to-os-specific-custom-name"><dfn>os specific custom name</dfn></h3>
+
+		: Output
+		:: |webCustomFormat|, a string
+
+		On Windows, follow the convention described below:
+
+		1. Assign "Web Custom Format" to |webCustomFormat|.
+
+		1. Return |webCustomFormat|.
+
+		On MacOS, follow the convention described below:
+
+		1. Assign "com.web.custom.format" to |webCustomFormat|.
+
+		1. Return |webCustomFormat|.
+
+		On Linux, ChromeOS, and Android, follow the convention described below:
+
+		1. Assign "application/web;type="custom/format" to |webCustomFormat|.
+
+		1. Return |webCustomFormat|.
+
+	</div><!-- algorithm -->
+

--- a/index.bs
+++ b/index.bs
@@ -655,7 +655,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<p> Returns {{ClipboardItem/types}} listed in the [=mandatory data types=] list that are present on the [=system clipboard=].
 
 		<dfn>getType({{DOMString}} type)</dfn>
-		<p> The {{ClipboardItem/getType}} must run the below steps:</p>
+		<p> The {{ClipboardItem/getType()}} must run the below steps:</p>
 
 			1. Let |p| be a new [=Promise=].
 

--- a/index.bs
+++ b/index.bs
@@ -621,8 +621,51 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		};
 		</pre>
 
-		<div id="clipboard-idl" dfn-for="Clipboard">
+		<dfn>ClipboardItemDataType</dfn>
+		<p>
+			Returns a {{DOMString}} or [=Blob=] type.
+		</p>
 
+		<dfn>ClipboardItemData</dfn>
+		<p>
+			Returns a [=Promise=] to the [=ClipboardItemDataType=].
+		</p>
+
+		{{ClipboardItem}}
+		<p> A {{ClipboardItem}} object contains the {{ClipboardItem/types}} listed in the [=mandatory data types=] list that are present on the [=system clipboard=].
+		<p> The {{ClipboardItem/constructor()}} step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code>
+		is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
+		</p>
+
+		Issue: Add definition to clarify what {{ClipboardItem/createDelayed()}} method does. From the discussions it looks like a Windows/Mac only feature where the
+		platform supports writing of the data to the system clipboard in a delayed fashion so the system clipboard can request data on-demand.
+		See https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations#delayed-rendering
+
+		<dfn>presentationStyle</dfn>
+		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.
+		The IDL attribute must [=reflect=] the respective content attributes of the same name.</p>
+
+		<p>{{ClipboardItem/presentationStyle}} getter steps are to return [=this=]'s {{ClipboardItem/presentationStyle}}</p>
+
+		Issue: Currently {{ClipboardItem/lastModified}} is not supported in Chromium and Safari, Should we remove it?
+
+		Issue: Delay rendering support has not been added to Chromium and Safari so {{ClipboardItem/delayed}} is unused.
+
+		<dfn>types</dfn>
+		<p> Returns {{ClipboardItem/types}} listed in the [=mandatory data types=] list that are present on the [=system clipboard=].
+
+		<dfn>getType({{DOMString}} type)</dfn>
+		<p> The {{ClipboardItem/getType}} must run the below steps:</p>
+
+			1. Let |p| be a new [=Promise=].
+
+			1. If |type| is not listed in the [=mandatory data types=] list, then reject |p| with a "The type was not found" DOMException.
+
+			1. Let |data| be the result of reading the |type| from the [=system clipboard=].
+
+			1. Resolve |p| with |data|.
+
+		<div id="clipboard-idl" dfn-for="Clipboard">
 		<div class="algorithm" data-algorithm="clipboard-read">
 		<h4 method for="Clipboard">read()</h4>
 		The {{Clipboard/read()}} method must run these steps:
@@ -632,6 +675,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			1. Run the following steps [=in parallel=]:
 
 				1. Let |r| be the result of running [=check clipboard read permission=] [=in parallel=]
+					Note: Clipboard permission is not supported on Safari. However, the read() method must be called inside
+					a user gesture event and the user must select the paste option from the native context menu that pops up
+					when read() is called from JS, otherwise, the promise will be rejected.
 
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
@@ -1260,6 +1306,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	Ojan Vafai,
 	Tarquin Wilton-Jones,
 	Tom Wlodkowski,
+	Bo Cupp,
 	and Boris Zbarsky.
 
 

--- a/index.bs
+++ b/index.bs
@@ -577,7 +577,6 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<div class="algorithm" data-algorithm="navigator-clipboard">
 		<h4 id="h-navigator-clipboard"><dfn>clipboard</dfn></h4>
 		The [=clipboard=] attribute must return the {{Navigator}}'s [=clipboard=] object.
-		The [=clipboard=] attribute is used to execute read/write operation from/to the [=system clipboard=].
 		</div>
 
 		</div><!-- dfn-for Navigator -->
@@ -658,12 +657,18 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 		<dfn>ClipboardItemDataType</dfn>
 		<p>
-			A {{DOMString}} or [=Blob=] type. This contains the payload corresponding to the MIME type while creating a {{ClipboardItem}} object.
+			Returns a {{DOMString}} or [=Blob=] type.
 		</p>
 
 		<dfn>ClipboardItemData</dfn>
 		<p>
-			A [=Promise=] to the [=ClipboardItemDataType=].
+			Returns a [=Promise=] to the [=ClipboardItemDataType=].
+		</p>
+
+		{{ClipboardItem}}
+		<p> A {{ClipboardItem}} object contains the {{ClipboardItem/types}} listed in the [=mandatory data types=] list that are present on the [=system clipboard=].
+		<p> The {{ClipboardItem/constructor()}} step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code>
+		is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
 		</p>
 
 		Issue: Add definition to clarify what {{ClipboardItem/createDelayed()}} method does. From the discussions it looks like a Windows/Mac only feature where the
@@ -671,7 +676,8 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		See https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations#delayed-rendering
 
 		<dfn>presentationStyle</dfn>
-		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.</p>
+		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.
+		The IDL attribute must [=reflect=] the respective content attributes of the same name.</p>
 
 		<p>{{ClipboardItem/presentationStyle}} getter steps are to return [=this=]'s {{ClipboardItem/presentationStyle}}</p>
 
@@ -693,6 +699,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 			1. Resolve |p| with |data|.
 
+		<div id="clipboard-idl" dfn-for="Clipboard">
 		<div class="algorithm" data-algorithm="clipboard-read">
 		<h4 method for="Clipboard">read()</h4>
 		The {{Clipboard/read()}} method must run these steps:
@@ -709,10 +716,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |data| be a copy of the [=system clipboard data=] represented as
-					a sequence of {{ClipboardItem}}s. For the MIME types defined in the [=mandatory data types=] list,
-					|data| contains the sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
-
-					Note: Currently in Chromium, only a single {{ClipboardItem}} object is supported for reading and writing via [=clipboard=] object.
+					a sequence of {{ClipboardItem}}s.
 					
 					Note: As further described in [[#image-transcode]] this explicitly does not transcode images.
 					Rather the original unmodified image data should be exposed to the website.
@@ -777,20 +781,11 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
-				1. Let |itemList| and |cleanItemList| be an empty sequence&lt;{{Blob}}>.
+				1. Let |cleanItemList| be an empty sequence&lt;{{Blob}}>.
 
-				1. For each |item| in |data|:
-					1. If [=Promise=] to {{Blob}} in |item| is rejected, then throw "Promises to Blobs were rejected." DOMException.
+				1. For each {{Blob}} |item| in |data|:
 
-					1. Add the {{Blob}} in |item| to |itemList| after the promise has been resolved.
-
-				1. For each {{Blob}} |itemBlob| in |itemList|:
-
-					1. If {{Blob/type}} is not in the [=mandatory data types=] list, then reject |p| with a "Type {{Blob/type}} not supported on write." DOMException.
-
-					1. Let |cleanItem| be a sanitized copy of |itemBlob|.
-
-						Issue: Add definition of sanitized copy.
+					1. Let |cleanItem| be a sanitized copy of |item|.
 
 					1. If unable to create a sanitized copy, then reject |p|.
 
@@ -805,7 +800,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			<div></div>
 
 			<pre class="example javascript">
-				var data = [new ClipboardItem({ "text/plain": Promise.resolve(new Blob(["Text data"], { type: "text/plain" }) }))];
+				var data = [new ClipboardItem({ "text/plain": new Blob(["Text data"], { type: "text/plain" }) })];
 				navigator.clipboard.write(data).then(function() {
 					console.log("Copied to clipboard successfully!");
 				}, function() {

--- a/index.bs
+++ b/index.bs
@@ -900,7 +900,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				// This format 'text/custom' is not sanitized by the Clipboard API. It will be
 				// pickled if the format is specified in the {unsanitized: []} formats list.
 				const customText = new Blob(
-				['<custom_markup>pickled_text</custom_markup>'], {type: 'text/custom'});
+				['&lt;custom_markup&gt; pickled_text&lt;/custom_markup&gt;'], {type: 'text/custom'});
 
 				// Clipboard format ordering: Pickled formats will be written before sanitized
 				// formats by the browser, since they're more "custom" and likely more targeted

--- a/index.bs
+++ b/index.bs
@@ -648,7 +648,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			</div>
 
 			<dt><code><var>clipboardItem</var> . <a method for=ClipboardItem lt=getType()>getType</a>(<var>type</var>)</code>
-			<dd><p>Returns a  [=Promise=] to the [=Blob=] corresponding to the <var>type</var>.
+			<dd><p>Returns a  [=Promise=] to the [=Blob=] corresponding to the <var>type</var>.</p>
 
 			<dt><code><var>types</var> of <var>clipboardItem</var></code>
 			<dd><p>Returns the list of <var>types</var> contained in the <var>clipboardItem</var> object.

--- a/index.bs
+++ b/index.bs
@@ -585,24 +585,18 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	<h3 id="clipboard-item-interface">ClipboardItem Interface</h3>
 		<pre class="idl" data-highlight="webidl">
 			typedef (DOMString or Blob) ClipboardItemDataType;
-			typedef Promise&lt;ClipboardItemDataType> ClipboardItemData;
+			typedef Promise&lt;ClipboardItemDataType&gt; ClipboardItemData;
 
 			callback ClipboardItemDelayedCallback = ClipboardItemData ();
 
 			[SecureContext, Exposed=Window] interface ClipboardItem {
 			constructor(record&lt;DOMString, ClipboardItemData> items,
 				optional ClipboardItemOptions options = {});
-			static ClipboardItem createDelayed(
-				record&lt;DOMString, ClipboardItemDelayedCallback> items,
-				optional ClipboardItemOptions options = {});
 
 			readonly attribute PresentationStyle presentationStyle;
-			readonly attribute long long lastModified;
-			readonly attribute boolean delayed;
-
 			readonly attribute FrozenArray&lt;DOMString> types;
 
-			Promise&lt;Blob> getType(DOMString type);
+			Promise&lt;Blob&gt; getType(DOMString type);
 			};
 
 			enum PresentationStyle { "unspecified", "inline", "attachment" };
@@ -612,11 +606,21 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			};
 		</pre>
 		<p><dfn export for=ClipboardItem id=concept-clipboard-item>ClipboardItem</dfn></p>
-		The [=ClipboardItem=] object has MIME types that are in the {{ClipboardItem/types}} list, and [=Blob=]s corresponding to the {{ClipboardItem/types}}.
-		It has a mapping of the MIME types in {{DOMString}} format and a [=Blob=] corresponding to the MIME types that contains the actual payload.
-		There can be multiple [=ClipboardItem=]s as each [=ClipboardItem=] represents contents of a clipboard, and there can be multiple clipboards supported on a platform such as iOS/iPadOS.
-		A web author needs to create a |data| which is a [=ClipboardItems=] object in order to write content to multiple clipboards using the {{Clipboard/write(data)}} method. {{Clipboard/read()}} returns a [=Promise=] to [=ClipboardItems=] object
-		that represents contents of multiple clipboards. A [=ClipboardItem=] can be read from [=ClipboardItems=], which then can be used to read a specific |type| using {{ClipboardItem/getType(type)}}.
+		A [=ClipboardItem=] is conceptually data that the user has expressed a desire to make shareable by invoking a "cut" or "copy" command.
+		For example, if a user copies a range of cells from a spreadsheet, it will result in one [=ClipboardItem=]. If a user copies a set of files from their desktop, that list of files will be a different single [=ClipboardItem=].
+		Some platforms may support having more than one [=ClipboardItem=] at a time on the [=Clipboard=], while other platforms replace the previous [=ClipboardItem=] with the new one. 
+
+		Each [=ClipboardItem=] can be represented as multiple mime-types. In the example where the user copies a range of cells from a spreadsheet, it may be represented as an image (image/png), an HTML table (text/html), or plain text (text/plain).
+		Each of these mime-types describe the same [=ClipboardItem=] at different levels of fidelity and make the [=ClipboardItem=] more consumable by target applications during paste.
+		Making the range of cells available as an image will allow the user to paste the cells into Photoshop, while the text/plain format can be used by applications like Windows Notepad.
+
+		Apps that support pasting only a single [=ClipboardItem=] should use the first [=ClipboardItem=].
+		Apps that support pasting more than one [=ClipboardItem=] could, for example, provide a user interface that previews the contents of each [=ClipboardItem=] and allow the user to choose which one to paste.
+		Further, apps are expected to enumerate the mime-types of the [=ClipboardItem=] they are pasting and select the one best-suited for the app according to some app-specific algorithm.
+		Alternatively, an app can present the user with options on how to paste a [=ClipboardItem=], e.g. “paste as image” or “paste formatted text”, etc.
+
+		A [=ClipboardItem=] contains multiple representations. Each representation consists of a MIME type and a corresponding {{DOMString}} or [=Blob=].
+
 		<dl class=note>
 			<dt><code><var>clipboardItem</var> = new ClipboardItem([<var>items</var>, <var>options</var>])</code>
 			<dd>
@@ -632,7 +636,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			</pre>
 
 			<dt><code><var>clipboardItem</var>.getType(<var>type</var>)</code>
-			<dd><p>Returns a  [=Promise=] to the [=Blob=] corresponding to the <var>type</var>.</p>
+			<dd><p>Returns a [=Promise=] to the [=Blob=] corresponding to <var>type</var>.</p>
 
 			<dt><code><var>clipboardItem</var>.<var>types</var></code>
 			<dd><p>Returns the list of <var>types</var> contained in the <var>clipboardItem</var> object.
@@ -641,10 +645,6 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<p>
 			The <a constructor lt="ClipboardItem()">ClipboardItem</a> step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code> is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
 		</p>
-
-		Issue: Add definition to clarify what {{ClipboardItem/createDelayed()}} method does. From the discussions it looks like a Windows/Mac only feature where the
-		platform supports writing of the data to the system clipboard in a delayed fashion so the system clipboard can request data on-demand.
-		See https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations#delayed-rendering
 
 		<h4 attribute for=ClipboardItem lt=presentationStyle>presentationStyle</h4>
 		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.
@@ -656,10 +656,6 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 		<p>{{ClipboardItem/presentationStyle}} getter steps are to return [=this=]'s {{ClipboardItem/presentationStyle}}</p>
 
-		Issue: Currently {{ClipboardItem/lastModified}} is not supported in Chromium and Safari, Should we remove it?
-
-		Issue: Delay rendering support has not been added to Chromium and Safari so {{ClipboardItem/delayed}} is unused.
-
 		<h4 attribute for=ClipboardItem lt=types>types</h4>
 		<p> Returns the MIME types used to create the [=ClipboardItem=] object.</p>
 		<p>{{ClipboardItem/types}} getter steps are to return [=this=]'s {{ClipboardItem/types}}</p>
@@ -670,9 +666,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 			1. If |type| is not listed in the [=mandatory data types=] list, then reject |p| with a "The type was not found" DOMException.
 
-			1. Let |data| be the result of reading the |type| from the [=system clipboard=].
-
-			1. Let |blobData| be the |data| represented as a [=Blob=].
+			1. Let |blobData| be a [=Blob=] corresponding to the |type|.
 
 			1. Resolve |p| with |blobData|.
 
@@ -682,21 +676,26 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		</p>
 		<h4 typedef>ClipboardItemData</h4>
 		<p>
-			It is a [=Promise=] to the {{ClipboardItemDataType}}.
+			A [=Promise=] to a {{ClipboardItemDataType}}.
 		</p>
 
 	<h3 id="clipboard-interface">Clipboard Interface</h3>
 
 		<pre class="idl" data-highlight="webidl">
-		typedef sequence&lt;ClipboardItem> ClipboardItems;
+		typedef sequence&lt;ClipboardItem&gt; ClipboardItems;
 
 		[SecureContext, Exposed=Window] interface Clipboard : EventTarget {
-		  Promise&lt;ClipboardItems> read();
-		  Promise&lt;DOMString> readText();
-		  Promise&lt;undefined> write(ClipboardItems data);
-		  Promise&lt;undefined> writeText(DOMString data);
+		  Promise&lt;ClipboardItems&gt; read();
+		  Promise&lt;DOMString&gt; readText();
+		  Promise&lt;undefined&gt; write(ClipboardItems data);
+		  Promise&lt;undefined&gt; writeText(DOMString data);
 		};
 		</pre>
+
+		A [=Clipboard=] may contain one or more [=ClipboardItem=]s. Multiple [=ClipboardItem=]s are only supported on platforms such as iOS/iPadOS.
+		A web author needs to create a |data| which is a [=ClipboardItems=] object in order to write content to clipboard using the {{Clipboard/write(data)}} method.
+		{{Clipboard/read()}} returns a [=Promise=] to [=ClipboardItems=] object that represents contents of clipboard.
+		A [=ClipboardItem=] can be read from [=ClipboardItems=], which then can be used to read a specific |type| using {{ClipboardItem/getType(type)}}.
 
 		<h4 typedef>ClipboardItems</h4>
 		<p>A sequence of [=ClipboardItem=] objects</p>
@@ -711,6 +710,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			1. Run the following steps [=in parallel=]:
 
 				1. Let |r| be the result of running [=check clipboard read permission=] [=in parallel=]
+
 					Note: Clipboard permission is not supported on Safari. However, the read() method must be called inside
 					a user gesture event and the user must select the paste option from the native context menu that pops up
 					when read() is called from JS, otherwise, the promise will be rejected.
@@ -719,7 +719,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. Let |data| be a copy of the [=system clipboard data=] represented as [=ClipboardItems=]. For the MIME types defined in the [=mandatory data types=] list, |data| contains the sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
 
-					Note: Currently in Chromium, only one [=ClipboardItem=] object is supported for reading and writing via [=clipboard=] object.
+					Note: Currently in Chromium, only one [=ClipboardItem=] object is supported for reading and writing via the [=clipboard=] object.
 					
 					Note: As further described in [[#image-transcode]] this explicitly does not transcode images.
 					Rather the original unmodified image data should be exposed to the website.
@@ -747,6 +747,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			1. Run the following steps [=in parallel=]:
 
 				1. Let |r| be the result of running [=check clipboard read permission=] [=in parallel=]
+
+				Note: Clipboard permission is not supported on Safari. However, the read() method must be called inside
+				a user gesture event and the user must select the paste option from the native context menu that pops up
+				when read() is called from JS, otherwise, the promise will be rejected.
 
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
@@ -782,30 +786,43 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. Let |r| be the result of running [=check clipboard write permission=] [=in parallel=]
 
+				Note: Clipboard permission is not supported on Safari. However, the read() method must be called inside
+				a user gesture event and the user must select the paste option from the native context menu that pops up
+				when read() is called from JS, otherwise, the promise will be rejected.
+
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
-				1. Let |itemList| and |cleanItemList| be an empty sequence&lt;{{Blob}}>.
+				1. Let |itemList| and |cleanItemList| be an empty sequence&lt;{{Blob}}&gt;.
 
-				1. For each |itemData| in |data|:
+				1. Let |clipboardItemList| be an empty [=ClipboardItems=].
 
-					1. For each |item| in |itemData|:
+				1. For each |clipboardItem| in |data|:
+
+					1. For each |item| in |clipboardItem|:
 						1. If [=Promise=] to {{Blob}} in |item| is rejected, then throw "Promises to Blobs were rejected." DOMException.
 
 						1. Add the {{Blob}} in |item| to |itemList| after the promise has been resolved.
 
-					1. For each {{Blob}} |itemBlob| in |itemList|:
+					1. For each {{Blob}} |blob| in |itemList|:
 
-						1. If {{Blob/type}} is not in the [=mandatory data types=] list, then reject |p| with a "Type {{Blob/type}} not supported on write." DOMException.
+						1. Let |type| be the |blob|'s {{Blob/type}}.
 
-						1. Let |cleanItem| be a sanitized copy of |itemBlob|.
+						1. If |type| is not in the [=mandatory data types=] list, then reject |p| with a "Type |type| not supported on write." DOMException.
+
+						1. Let |cleanItem| be a sanitized copy of |blob|.
 
 							Issue: Add definition of sanitized copy.
 
 						1. If unable to create a sanitized copy, then reject |p|.
 
 						1. Add |cleanItem| to |cleanItemList|.
+					
+					1. Add |cleanItemList| to |clipboardItemList|.
 
-					1. Replace the [=system clipboard data=] with |cleanItemList|.
+				1. Replace the [=system clipboard data=] with |clipboardItemList|.
+
+				Note: Writing multiple [=ClipboardItem=]s to the clipboard is only supported on MacOS.
+				For other platforms, only the first [=ClipboardItem=] should be written to the clipboard.
 
 				1. Resolve |p|.
 
@@ -833,6 +850,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			1. Run the following steps [=in parallel=]:
 
 				1. Let |r| be the result of running [=check clipboard write permission=] [=in parallel=]
+
+				Note: Clipboard permission is not supported on Safari. However, the read() method must be called inside
+				a user gesture event and the user must select the paste option from the native context menu that pops up
+				when read() is called from JS, otherwise, the promise will be rejected.
 
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 

--- a/index.bs
+++ b/index.bs
@@ -577,6 +577,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<div class="algorithm" data-algorithm="navigator-clipboard">
 		<h4 id="h-navigator-clipboard"><dfn>clipboard</dfn></h4>
 		The [=clipboard=] attribute must return the {{Navigator}}'s [=clipboard=] object.
+		It is used to execute read/write operation from/to the [=system clipboard=].
 		</div>
 
 		</div><!-- dfn-for Navigator -->
@@ -657,12 +658,12 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 		<dfn>ClipboardItemDataType</dfn>
 		<p>
-			Returns a {{DOMString}} or [=Blob=] type.
+			A {{DOMString}} or [=Blob=] type. This contains the payload corresponding to the MIME type while creating a {{ClipboardItem}} object.
 		</p>
 
 		<dfn>ClipboardItemData</dfn>
 		<p>
-			Returns a [=Promise=] to the [=ClipboardItemDataType=].
+			A [=Promise=] to the [=ClipboardItemDataType=].
 		</p>
 
 		{{ClipboardItem}}
@@ -676,8 +677,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		See https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations#delayed-rendering
 
 		<dfn>presentationStyle</dfn>
-		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.
-		The IDL attribute must [=reflect=] the respective content attributes of the same name.</p>
+		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.</p>
 
 		<p>{{ClipboardItem/presentationStyle}} getter steps are to return [=this=]'s {{ClipboardItem/presentationStyle}}</p>
 
@@ -716,7 +716,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |data| be a copy of the [=system clipboard data=] represented as
-					a sequence of {{ClipboardItem}}s.
+					a sequence of {{ClipboardItem}}s. For the MIME types defined in the [=mandatory data types=] list,
+					|data| contains the sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
+
+					Note: Currently in Chromium, only a single {{ClipboardItem}} object is supported for reading and writing via [=clipboard=] object.
 					
 					Note: As further described in [[#image-transcode]] this explicitly does not transcode images.
 					Rather the original unmodified image data should be exposed to the website.
@@ -781,11 +784,20 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
-				1. Let |cleanItemList| be an empty sequence&lt;{{Blob}}>.
+				1. Let |itemList| and |cleanItemList| be an empty sequence&lt;{{Blob}}>.
 
-				1. For each {{Blob}} |item| in |data|:
+				1. For each |item| in |data|:
+					1. If [=Promise=] to {{Blob}} in |item| is rejected, then throw "Promises to Blobs were rejected." DOMException.
 
-					1. Let |cleanItem| be a sanitized copy of |item|.
+					1. Add the {{Blob}} in |item| to |itemList| after the promise has been resolved.
+
+				1. For each {{Blob}} |itemBlob| in |itemList|:
+
+					1. If {{Blob/type}} is not in the [=mandatory data types=] list, then reject |p| with a "Type {{Blob/type}} not supported on write." DOMException.
+
+					1. Let |cleanItem| be a sanitized copy of |itemBlob|.
+
+						Issue: Add definition of sanitized copy.
 
 					1. If unable to create a sanitized copy, then reject |p|.
 
@@ -800,7 +812,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			<div></div>
 
 			<pre class="example javascript">
-				var data = [new ClipboardItem({ "text/plain": new Blob(["Text data"], { type: "text/plain" }) })];
+				var data = [new ClipboardItem({ "text/plain": Promise.resolve(new Blob(["Text data"], { type: "text/plain" }) }))];
 				navigator.clipboard.write(data).then(function() {
 					console.log("Copied to clipboard successfully!");
 				}, function() {

--- a/index.bs
+++ b/index.bs
@@ -577,6 +577,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<div class="algorithm" data-algorithm="navigator-clipboard">
 		<h4 id="h-navigator-clipboard"><dfn>clipboard</dfn></h4>
 		The [=clipboard=] attribute must return the {{Navigator}}'s [=clipboard=] object.
+		The [=clipboard=] attribute is used to execute read/write operation from/to the [=system clipboard=].
 		</div>
 
 		</div><!-- dfn-for Navigator -->
@@ -621,20 +622,50 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		};
 		</pre>
 
+		<div class="algorithm" data-algorithm="clipboard-item">
+		<h4 id="h-clipboard-item"><dfn>ClipboardItem</dfn></h4>
+		The [=ClipboardItem=] object represents the content of the MIME types that are in the [=mandatory data types=] list, and are currently on the [=system clipboard=].
+		It has a mapping of the MIME types in {{DOMString}} format and a [=Blob=] corresponding to the MIME types that contains the actual payload. A web author needs to
+		create a [=ClipboardItem=] object in order to write content to the clipboard using the {{Clipboard/write()}} method. {{Clipboard/read()}} returns a [=ClipboardItem=] object
+		that can be used to read a specific |type| using {{ClipboardItem/getType()}}.
+		</div>
+		<dl class=note>
+			<dt><code><var>clipboardItem</var> = new <a constructor lt="ClipboardItem()">ClipboardItem</a>([<var>items</var>, <var>options</var>])</code>
+			<dd>
+			Creates a new {{ClipboardItem}} object. <var>items</var> are used to fill its MIME types and [=Promise=]s to [=Blob=]s corresponding to the MIME types, <var>options</var> can be used to fill its {{ClipboardItemOptions}},
+			as per the example below.
+
+			<div class=example id=example-clipboard-item-class>
+			<pre><code class=lang-javascript>
+			const format1 = 'text/plain';
+			const format2 = 'text/html';
+			const promise_text_blob = Promise.resolve(new Blob(['hello'], {type: format1}));
+			const promise_html_blob = Promise.resolve(new Blob(['<p style='color: red; font-style: oblique;'>Test</p>'], {type: format2}));
+			const clipboardItemInput = new ClipboardItem(
+				{[format1]: promise_text_blob, [format2]: promise_html_blob},
+				{options: "unspecified"});
+			</code></pre>
+			</div>
+
+			<dt><code><var>clipboardItem</var> . <a method for=ClipboardItem lt=getType()>getType</a>(<var>type</var>)</code>
+			<dd><p>Returns a  [=Promise=] to the [=Blob=] corresponding to the <var>type</var>.
+
+			<dt><code><var>types</var> of <var>clipboardItem</var></code>
+			<dd><p>Returns the list of <var>types</var> contained in the <var>clipboardItem</var> object.
+
+		</dl>
+		<p>
+			The {{ClipboardItem/constructor()}} step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code> is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
+		</p>
+
 		<dfn>ClipboardItemDataType</dfn>
 		<p>
-			Returns a {{DOMString}} or [=Blob=] type.
+			A {{DOMString}} or [=Blob=] type. This contains the payload corresponding to the MIME type while creating a {{ClipboardItem}} object.
 		</p>
 
 		<dfn>ClipboardItemData</dfn>
 		<p>
-			Returns a [=Promise=] to the [=ClipboardItemDataType=].
-		</p>
-
-		{{ClipboardItem}}
-		<p> A {{ClipboardItem}} object contains the {{ClipboardItem/types}} listed in the [=mandatory data types=] list that are present on the [=system clipboard=].
-		<p> The {{ClipboardItem/constructor()}} step for <code>new ClipboardItem(<var>items</var>, <var>options</var>)</code>
-		is to set [=this=]'s items to <var>items</var> and options to <var>options</var>
+			A [=Promise=] to the [=ClipboardItemDataType=].
 		</p>
 
 		Issue: Add definition to clarify what {{ClipboardItem/createDelayed()}} method does. From the discussions it looks like a Windows/Mac only feature where the
@@ -642,8 +673,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		See https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations#delayed-rendering
 
 		<dfn>presentationStyle</dfn>
-		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.
-		The IDL attribute must [=reflect=] the respective content attributes of the same name.</p>
+		<p>It is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>unspecified</code>, <code>inline</code> and <code>attachment</code>.</p>
 
 		<p>{{ClipboardItem/presentationStyle}} getter steps are to return [=this=]'s {{ClipboardItem/presentationStyle}}</p>
 
@@ -665,7 +695,6 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 			1. Resolve |p| with |data|.
 
-		<div id="clipboard-idl" dfn-for="Clipboard">
 		<div class="algorithm" data-algorithm="clipboard-read">
 		<h4 method for="Clipboard">read()</h4>
 		The {{Clipboard/read()}} method must run these steps:
@@ -682,7 +711,10 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
 				1. Let |data| be a copy of the [=system clipboard data=] represented as
-					a sequence of {{ClipboardItem}}s.
+					a sequence of {{ClipboardItem}}s. For the MIME types defined in the [=mandatory data types=] list,
+					|data| contains the sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
+
+					Note: Currently in Chromium, only a single {{ClipboardItem}} object is supported for reading and writing via [=clipboard=] object.
 					
 					Note: As further described in [[#image-transcode]] this explicitly does not transcode images.
 					Rather the original unmodified image data should be exposed to the website.
@@ -747,11 +779,20 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
 
-				1. Let |cleanItemList| be an empty sequence&lt;{{Blob}}>.
+				1. Let |itemList| and |cleanItemList| be an empty sequence&lt;{{Blob}}>.
 
-				1. For each {{Blob}} |item| in |data|:
+				1. For each |item| in |data|:
+					1. If [=Promise=] to {{Blob}} in |item| is rejected, then throw "Promises to Blobs were rejected." DOMException.
 
-					1. Let |cleanItem| be a sanitized copy of |item|.
+					1. Add the {{Blob}} in |item| to |itemList| after the promise has been resolved.
+
+				1. For each {{Blob}} |itemBlob| in |itemList|:
+
+					1. If {{Blob/type}} is not in the [=mandatory data types=] list, then reject |p| with a "Type {{Blob/type}} not supported on write." DOMException.
+
+					1. Let |cleanItem| be a sanitized copy of |itemBlob|.
+
+						Issue: Add definition of sanitized copy.
 
 					1. If unable to create a sanitized copy, then reject |p|.
 
@@ -766,7 +807,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			<div></div>
 
 			<pre class="example javascript">
-				var data = [new ClipboardItem({ "text/plain": new Blob(["Text data"], { type: "text/plain" }) })];
+				var data = [new ClipboardItem({ "text/plain": Promise.resolve(new Blob(["Text data"], { type: "text/plain" }) }))];
 				navigator.clipboard.write(data).then(function() {
 					console.log("Copied to clipboard successfully!");
 				}, function() {

--- a/index.bs
+++ b/index.bs
@@ -638,11 +638,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 			<div class=example id=example-clipboard-item-class>
 			<pre><code class=lang-javascript>
 			const format1 = 'text/plain';
-			const format2 = 'text/html';
 			const promise_text_blob = Promise.resolve(new Blob(['hello'], {type: format1}));
-			const promise_html_blob = Promise.resolve(new Blob(['<p style='color: red; font-style: oblique;'>Test</p>'], {type: format2}));
 			const clipboardItemInput = new ClipboardItem(
-				{[format1]: promise_text_blob, [format2]: promise_html_blob},
+				{[format1]: promise_text_blob},
 				{options: "unspecified"});
 			</code></pre>
 			</div>

--- a/index.bs
+++ b/index.bs
@@ -662,13 +662,17 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 
 		<h4 method for=ClipboardItem lt=getType(type)>getType(type)</a> must run the below steps:</h4>
 
-			1. Let |p| be a new [=Promise=].
+			1. Let |realm| be [=this=]'s [=relevant realm=].
 
-			1. If |type| is not listed in the [=mandatory data types=] list, then reject |p| with a "The type was not found" DOMException.
+			1. If |type| is not listed in the [=mandatory data types=] list, then [=a promise rejected with=] "The type was not found" DOMException in |realm|.
+
+			1. Let |p| be [=a new promise=] in |realm|.
 
 			1. Let |blobData| be a [=Blob=] corresponding to the |type|.
 
 			1. Resolve |p| with |blobData|.
+
+			1. Return |p|.
 
 		<h4 typedef>ClipboardItemDataType</h4>
 		<p>
@@ -705,7 +709,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<h4 method for="Clipboard">read()</h4>
 		The {{Clipboard/read()}} method must run these steps:
 
-			1. Let |p| be a new [=Promise=].
+			1. Let |realm| be [=this=]'s [=relevant realm=].
+
+			1. Let |p| be [=a new promise=] in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 
@@ -715,7 +721,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 					a user gesture event and the user must select the paste option from the native context menu that pops up
 					when read() is called from JS, otherwise, the promise will be rejected.
 
-				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
+				1. If |r| is not "granted", then [=a promise rejected with=] "NotAllowedError" DOMException in |realm|.
 
 				1. Let |data| be a copy of the [=system clipboard data=] represented as [=ClipboardItems=]. For the MIME types defined in the [=mandatory data types=] list, |data| contains the sanitized copy of text/html format, but image/png format has unsanitized payload to preserve meta data.
 
@@ -742,7 +748,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<h4 method for="Clipboard">readText()</h4>
 		The {{Clipboard/readText()}} method must run these steps:
 
-			1. Let |p| be a new [=Promise=].
+			1. Let |realm| be [=this=]'s [=relevant realm=].
+
+			1. Let |p| be [=a new promise=] in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 
@@ -752,7 +760,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				a user gesture event and the user must select the paste option from the native context menu that pops up
 				when read() is called from JS, otherwise, the promise will be rejected.
 
-				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
+				1. If |r| is not "granted", then [=a promise rejected with=] "NotAllowedError" DOMException in |realm|.
 
 				1. Let |data| be a copy of the [=system clipboard data=].
 
@@ -780,7 +788,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<h4 method for="Clipboard">write(|data|)</h4>
 		The {{Clipboard/write(data)}} method must run these steps:
 
-			1. Let |p| be a new [=Promise=].
+			1. Let |realm| be [=this=]'s [=relevant realm=].
+
+			1. Let |p| be [=a new promise=] in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 
@@ -790,7 +800,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				a user gesture event and the user must select the paste option from the native context menu that pops up
 				when read() is called from JS, otherwise, the promise will be rejected.
 
-				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
+				1. If |r| is not "granted", then [=a promise rejected with=] "NotAllowedError" DOMException in |realm|.
 
 				1. Let |itemList| and |cleanItemList| be an empty sequence&lt;{{Blob}}&gt;.
 
@@ -799,21 +809,24 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				1. For each |clipboardItem| in |data|:
 
 					1. For each |item| in |clipboardItem|:
-						1. If [=Promise=] to {{Blob}} in |item| is rejected, then throw "Promises to Blobs were rejected." DOMException.
 
-						1. Add the {{Blob}} in |item| to |itemList| after the promise has been resolved.
+						1. Let |p1| be [=a new promise=] to {{Blob}} in |realm|.
+
+						1. If |p1| is [=reject=]d, then throw "Promises to Blobs were rejected." DOMException in |realm|.
+
+						1. Add the {{Blob}} in |item| to |itemList| after |p1| has been resolved.
 
 					1. For each {{Blob}} |blob| in |itemList|:
 
 						1. Let |type| be the |blob|'s {{Blob/type}}.
 
-						1. If |type| is not in the [=mandatory data types=] list, then reject |p| with a "Type |type| not supported on write." DOMException.
+						1. If |type| is not in the [=mandatory data types=] list, then [=a promise rejected with=] "Type |type| not supported on write." DOMException in |realm|.
 
 						1. Let |cleanItem| be a sanitized copy of |blob|.
 
 							Issue: Add definition of sanitized copy.
 
-						1. If unable to create a sanitized copy, then reject |p|.
+						1. If unable to create a sanitized copy, then [=reject=] |p|.
 
 						1. Add |cleanItem| to |cleanItemList|.
 					
@@ -845,7 +858,9 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		<h4 method for="Clipboard">writeText(|data|)</h4>
 		The {{Clipboard/writeText(data)}} method must run these steps:
 
-			1. Let |p| be a new [=Promise=].
+			1. Let |realm| be [=this=]'s [=relevant realm=].
+
+			1. Let |p| be [=a new promise=] in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 
@@ -855,7 +870,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 				a user gesture event and the user must select the paste option from the native context menu that pops up
 				when read() is called from JS, otherwise, the promise will be rejected.
 
-				1. If |r| is not "granted", then reject |p| with a "NotAllowedError" DOMException
+				1. If |r| is not "granted", then [=a promise rejected with=] "NotAllowedError" DOMException in |realm|.
 
 				1. Let |newItemList| be empty [=ClipboardItems=].
 


### PR DESCRIPTION
For normative changes, the following tasks have been completed:

 * [X] Modified Web platform tests (https://wpt.fyi/results/clipboard-apis?label=master&label=experimental&aligned&q=async%20clipboard)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=106449)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/162.html" title="Last updated on Nov 4, 2021, 4:37 PM UTC (1cda092)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/162/0f67e6a...1cda092.html" title="Last updated on Nov 4, 2021, 4:37 PM UTC (1cda092)">Diff</a>