### PR TITLE
[meta] Fix broken markup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -936,17 +936,13 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 	These clipboard permissions are <a>powerful feature</a>s
 	permission-related algorithms and types are defined as follows:
 
-	<dl>
-	<dt>
-		<a>permission descriptor type</a>
-	</dt>
-	<dd>
+	: <a>permission descriptor type</a>
+	::
 		<pre class="idl">
 			dictionary ClipboardPermissionDescriptor : PermissionDescriptor {
 				boolean allowWithoutGesture = false;
 			};
 		</pre>
-	</dd>
 
 	There are 4 clipboard permissions:
 


### PR DESCRIPTION
Your `dl` was unclosed. Went ahead and switched it to Markdown, as that requires less tracking anyway.
