### PR TITLE
Fix spec errors due to invalid markup.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -590,7 +590,7 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 		</pre>
 
 		<dl class=note>
-			<dt><code><var>clipboardItem</var> = new ClipboardItem([<var>items</var>, <var>options</var>])</code>
+			<dt><code><var>clipboardItem</var> = new ClipboardItem([<var>items</var>, <var>options</var>])</code></dt>
 			<dd>
 			Creates a new {{ClipboardItem}} object. <var>items</var> denote [=list of representations=], each [=representation=] has a [=representation/mime type=] and a [=Promise=] to {{Blob}} or {{DOMString}} corresponding to the [=representation/mime type=], <var>options</var> can be used to fill its {{ClipboardItemOptions}},
 			as per the example below.
@@ -602,13 +602,12 @@ urlPrefix: https://w3c.github.io/FileAPI/#dfn-; type: dfn;
 						{[format1]: promise_text_blob},
 						{presentationStyle: "unspecified"});
 				</pre>
+			</dd>
+			<dt><code><var>clipboardItem</var>.getType(<var>type</var>)</code></dt>
+			<dd>Returns a [=Promise=] to the {{Blob}} corresponding to the [=representation/mime type=] <var>type</var>.</dd>
 
-			<dt><code><var>clipboardItem</var>.getType(<var>type</var>)</code>
-			<dd><p>Returns a [=Promise=] to the {{Blob}} corresponding to the [=representation/mime type=] <var>type</var>.</p>
-
-			<dt><code><var>clipboardItem</var>.<var>types</var></code>
-			<dd><p>Returns the list of [=representation/mime type=]s contained in the [=/clipboard item=] object.
-
+			<dt><code><var>clipboardItem</var>.<var>types</var></code></dt>
+			<dd>Returns the list of [=representation/mime type=]s contained in the [=/clipboard item=] object.</dd>
 		</dl>
 
 		A <dfn>clipboard item</dfn> is conceptually data that the user has expressed a desire to make shareable by invoking a "cut" or "copy" command. A [=/clipboard item=] serves two purposes. First, it allows a website to read data copied by a user to the system clipboard. Second, it allows a website to write data to the system clipboard.


### PR DESCRIPTION
Spec errors in #158


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 8, 2022, 6:53 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fclipboard-apis%2F974e63cb1392ea12b434e3df6b761b5ff1e211ac%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/clipboard-apis%23172.)._
</details>
