### PR TITLE
Add 'starts with' to web custom format prefix.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -539,7 +539,9 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			* text/uri-list
 			* image/svg+xml
-			* Custom format [=starts with=] "web "("web" followed by U+0020 SPACE) prefix.
+			* Custom format [=starts with=] "web "("web" followed by U+0020 SPACE) prefix
+				and suffix (after stripping out "web "("web" followed by U+0020 SPACE)) is a valid
+				[=/MIME type=].
 
 
 <h2 id="async-clipboard-api">Asynchronous Clipboard API</h2>

--- a/index.bs
+++ b/index.bs
@@ -539,7 +539,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			* text/uri-list
 			* image/svg+xml
-			* Custom format with "web "("web" followed by U+0020 SPACE) prefix.
+			* Custom format [=starts with=] "web "("web" followed by U+0020 SPACE) prefix.
 
 
 <h2 id="async-clipboard-api">Asynchronous Clipboard API</h2>
@@ -669,7 +669,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 				1. Let |isCustom| be |false|.
 				
-				1. If |key| has "web " ("web" followed by U+0020 SPACE) prefix, then 
+				1. If |key| [=starts with=] "web " ("web" followed by U+0020 SPACE) prefix, then
 				
 					1. Remove "web " prefix and set the remaining string to |key|.
 
@@ -717,7 +717,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			1. Let |isCustom| be |false|.
 
-			1. If |type| has "web "("web" followed by U+0020 SPACE) prefix, then:
+			1. If |type| [=starts with=] "web "("web" followed by U+0020 SPACE) prefix, then:
 			
 				1. Remove "web " prefix and set the remaining string to |type|.
 
@@ -1695,7 +1695,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 				1. Let |webCustomFormat| be an empty {{Blob/type}}.
 
-				1. If |webCustomFormatString| has "web "("web" followed by U+0020 SPACE) prefix, then remove the "web " prefix and store the remaining string in |webCustomFormat|'s {{Blob/type}}'s [=MIME type/essence=], else abort all steps.
+				1. If |webCustomFormatString| [=starts with=] "web "("web" followed by U+0020 SPACE) prefix, then remove the "web " prefix and store the remaining string in |webCustomFormat|'s {{Blob/type}}'s [=MIME type/essence=], else abort all steps.
 				
 				1. Set |item|'s {{Blob/type}} to |webCustomFormat|.
 

--- a/index.bs
+++ b/index.bs
@@ -720,7 +720,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			1. If |type| [=string/starts with=] `"web "` prefix, then:
 			
-				1. Remove `"web "` prefix and set the remaining string to |type|.
+				1. Remove `"web "` prefix and assign the remaining string to |type|.
 
 				1. Set |isCustom| to |true|.
 

--- a/index.bs
+++ b/index.bs
@@ -539,9 +539,8 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			* text/uri-list
 			* image/svg+xml
-			* Custom format [=string/starts with=] "web "("web" followed by U+0020 SPACE) prefix
-				and suffix (after stripping out "web "("web" followed by U+0020 SPACE)) is a valid
-				[=/MIME type=].
+			* Custom format [=string/starts with=] `"web "`("web" followed by U+0020 SPACE) prefix
+				and suffix (after stripping out `"web "`) is a valid [=/MIME type=].
 
 
 <h2 id="async-clipboard-api">Asynchronous Clipboard API</h2>
@@ -671,9 +670,9 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 				1. Let |isCustom| be |false|.
 				
-				1. If |key| [=string/starts with=] "web " ("web" followed by U+0020 SPACE) prefix, then
+				1. If |key| [=string/starts with=] `"web "` prefix, then
 				
-					1. Remove "web " prefix and set the remaining string to |key|.
+					1. Remove `"web "` prefix and set the remaining string to |key|.
 
 					1. Set |isCustom| |true|
 					
@@ -695,7 +694,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 				1. Let |mimeTypeString| be the result of [=serializing a MIME type=] with |mimeType|.
 				
-				1. If |isCustom| is |true|, prefix |mimeTypeString| with "web " ("web" followed by U+0020 SPACE).
+				1. If |isCustom| is |true|, prefix |mimeTypeString| with `"web "`.
 				
 				1. Add |mimeTypeString| to |types|.
 
@@ -719,9 +718,9 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			1. Let |isCustom| be |false|.
 
-			1. If |type| [=string/starts with=] "web "("web" followed by U+0020 SPACE) prefix, then:
+			1. If |type| [=string/starts with=] `"web "` prefix, then:
 			
-				1. Remove "web " prefix and set the remaining string to |type|.
+				1. Remove `"web "` prefix and set the remaining string to |type|.
 
 				1. Set |isCustom| to |true|.
 
@@ -1697,7 +1696,13 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 				1. Let |webCustomFormat| be an empty {{Blob/type}}.
 
-				1. If |webCustomFormatString| [string/starts with=] "web "("web" followed by U+0020 SPACE) prefix, then remove the "web " prefix and store the remaining string in |webCustomFormat|'s {{Blob/type}}'s [=MIME type/essence=], else abort all steps.
+				1. If |webCustomFormatString| [=string/starts with=] `"web "` prefix, then remove the `"web "` prefix and store the remaining string in |webMimeTypeString|.
+				
+				1. Let |webMimeType| be the result of [=parsing a MIME type=] given |webMimeTypeString|.
+
+				1. If |webMimeType| is failure, then abort all steps.
+				
+				1. Let |webCustomFormat|'s {{Blob/type}}'s [=MIME type/essence=] equal to |webMimeType|.
 				
 				1. Set |item|'s {{Blob/type}} to |webCustomFormat|.
 

--- a/index.bs
+++ b/index.bs
@@ -539,7 +539,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			* text/uri-list
 			* image/svg+xml
-			* Custom format [=starts with=] "web "("web" followed by U+0020 SPACE) prefix
+			* Custom format [=string/starts with=] "web "("web" followed by U+0020 SPACE) prefix
 				and suffix (after stripping out "web "("web" followed by U+0020 SPACE)) is a valid
 				[=/MIME type=].
 
@@ -671,7 +671,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 				1. Let |isCustom| be |false|.
 				
-				1. If |key| [=starts with=] "web " ("web" followed by U+0020 SPACE) prefix, then
+				1. If |key| [=string/starts with=] "web " ("web" followed by U+0020 SPACE) prefix, then
 				
 					1. Remove "web " prefix and set the remaining string to |key|.
 
@@ -719,7 +719,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			1. Let |isCustom| be |false|.
 
-			1. If |type| [=starts with=] "web "("web" followed by U+0020 SPACE) prefix, then:
+			1. If |type| [=string/starts with=] "web "("web" followed by U+0020 SPACE) prefix, then:
 			
 				1. Remove "web " prefix and set the remaining string to |type|.
 
@@ -1697,7 +1697,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 				1. Let |webCustomFormat| be an empty {{Blob/type}}.
 
-				1. If |webCustomFormatString| [=starts with=] "web "("web" followed by U+0020 SPACE) prefix, then remove the "web " prefix and store the remaining string in |webCustomFormat|'s {{Blob/type}}'s [=MIME type/essence=], else abort all steps.
+				1. If |webCustomFormatString| [string/starts with=] "web "("web" followed by U+0020 SPACE) prefix, then remove the "web " prefix and store the remaining string in |webCustomFormat|'s {{Blob/type}}'s [=MIME type/essence=], else abort all steps.
 				
 				1. Set |item|'s {{Blob/type}} to |webCustomFormat|.
 

--- a/index.bs
+++ b/index.bs
@@ -540,7 +540,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 			* text/uri-list
 			* image/svg+xml
 			* Custom format [=string/starts with=] `"web "`("web" followed by U+0020 SPACE) prefix
-				and suffix (after stripping out `"web "`) is a valid [=/MIME type=].
+				and suffix (after stripping out `"web "`) passes the [=parsing a MIME type=] check.
 
 
 <h2 id="async-clipboard-api">Asynchronous Clipboard API</h2>
@@ -672,7 +672,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 				
 				1. If |key| [=string/starts with=] `"web "` prefix, then
 				
-					1. Remove `"web "` prefix and set the remaining string to |key|.
+					1. Remove `"web "` prefix and assign the remaining string to |key|.
 
 					1. Set |isCustom| |true|
 					


### PR DESCRIPTION
Closes https://github.com/w3c/clipboard-apis/pull/175#discussion_r1329392888

For normative changes, the following tasks have been completed:

 * [X] Modified Web platform tests (link to pull request): https://github.com/web-platform-tests/wpt/pull/41993

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/195.html" title="Last updated on Oct 24, 2023, 8:29 PM UTC (e3ae9c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/195/39b067c...e3ae9c5.html" title="Last updated on Oct 24, 2023, 8:29 PM UTC (e3ae9c5)">Diff</a>