### PR TITLE
Add `unsanitized` option to async clipboard API.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -544,17 +544,9 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 	<h3 id="unsanitized-data-types-x"><dfn>Unsanitized data types</dfn></h3>
 
-		The implementation MAY recognize the native OS clipboard format description
-		for the following data types, to be able to populate the
-		{{ClipboardItem}} with the correct [=/MIME type=], and
-		set the correct data format on the OS clipboard in response to copy and cut
-		events.
+			These data types MUST NOT be sanitized by UAs:
 
-			These data types must not be sanitized and should be exposed by UAs
-			if a corresponding native type exists on the clipboard:
-
-			* text/html
-
+			* image/png (which should remain unsanitized to preserve meta data)
 
 <h2 id="async-clipboard-api">Asynchronous Clipboard API</h2>
 
@@ -816,7 +808,11 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		{{Clipboard/read()}} returns a {{Promise}} to [=clipboard items=] object that represents contents of [=system clipboard data=].
 		</p>
 
-		{{ClipboardUnsanitizedFormats/unsanitized}} is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=] that are in the [=unsanitized data types=].
+		<dfn>Optional unsanitized data types</dfn> are [=representation/mime type=]s that MUST not be sanitized by the user agent. The valid [=optional unsanitized data types=] are listed below:
+
+			* text/html
+
+		{{ClipboardUnsanitizedFormats/unsanitized}} is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=] that are [=optional unsanitized data types=].
 
 		The <dfn>clipboard task source</dfn> is triggered in response to reading or writing of [=system clipboard data=].
 
@@ -833,7 +829,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 				1. For each |format| in |formats|["{{ClipboardUnsanitizedFormats/unsanitized}}"]:
 
-					1. If |format| is not in [=unsanitized data types=], then [=reject=] |p| with |format| {{"NotAllowedError"}} {{DOMException}} in |realm|.
+					1. If |format| is not in [=optional unsanitized data types=], then [=reject=] |p| with |format| {{"NotAllowedError"}} {{DOMException}} in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 
@@ -877,7 +873,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 						
 						1. The user agent, MUST NOT sanitize |representation|'s [=representation/data=], if it satisfies the below conditions:
 						
-							1. |representation|'s [=representation/MIME type=]'s [=MIME type/essence=] is "image/png", which should remain unsanitized to preserve meta data.
+							1. |representation|'s [=representation/MIME type=] is in [=unsanitized data types=] list.
 							
 							1. |isUnsanitized| is true.
 

--- a/index.bs
+++ b/index.bs
@@ -546,7 +546,11 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			These data types MUST NOT be sanitized by UAs:
 
-			* image/png (which should remain unsanitized to preserve meta data)
+			* image/png
+
+			<p class=note>
+				The image/png MIME type is not sanitized to preserve meta data.
+			</p>
 
 <h2 id="async-clipboard-api">Asynchronous Clipboard API</h2>
 
@@ -808,11 +812,10 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		{{Clipboard/read()}} returns a {{Promise}} to [=clipboard items=] object that represents contents of [=system clipboard data=].
 		</p>
 
-		<dfn>Optional unsanitized data types</dfn> are [=representation/mime type=]s that MUST not be sanitized by the user agent. The valid [=optional unsanitized data types=] are listed below:
+		{{ClipboardUnsanitizedFormats/unsanitized}} is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=] that are [=optional unsanitized data types=].
+		<dfn>Optional unsanitized data types</dfn> are [=representation/mime type=]s that MUST NOT be sanitized by the user agent. The valid [=optional unsanitized data types=] are listed below:
 
 			* text/html
-
-		{{ClipboardUnsanitizedFormats/unsanitized}} is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=] that are [=optional unsanitized data types=].
 
 		The <dfn>clipboard task source</dfn> is triggered in response to reading or writing of [=system clipboard data=].
 

--- a/index.bs
+++ b/index.bs
@@ -542,6 +542,19 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 			* Custom format [=string/starts with=] `"web "`("web" followed by U+0020 SPACE) prefix
 				and suffix (after stripping out `"web "`) passes the [=parsing a MIME type=] check.
 
+	<h3 id="unsanitized-data-types-x"><dfn>Unsanitized data types</dfn></h3>
+
+		The implementation MAY recognize the native OS clipboard format description
+		for the following data types, to be able to populate the
+		{{ClipboardItem}} with the correct description for paste events, and
+		set the correct data format on the OS clipboard in response to copy and cut
+		events.
+
+			These data types must not be sanitized and should be exposed by UAs
+			if a corresponding native type exists on the clipboard:
+
+			* text/html
+
 
 <h2 id="async-clipboard-api">Asynchronous Clipboard API</h2>
 
@@ -620,6 +633,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		Some platforms may support having more than one [=/clipboard item=] at a time on the [=clipboard=], while other platforms replace the previous [=/clipboard item=] with the new one.
 
 		A [=/clipboard item=] has a <dfn>list of representations</dfn>, each <dfn>representation</dfn> with an associated <dfn for=representation>mime type</dfn> (a [=/MIME type=]), an <dfn for="representation">isCustom</dfn> flag, initially |false|, that indicates if this [=representation=] should be treated as a [=web custom format=] (as opposed to a well-known format of the [=system clipboard=]), and <dfn for=representation>data</dfn> (a {{ClipboardItemData}}).
+
 		A <dfn>web custom format</dfn> has [=representation/isCustom=] set to |true|.
 
 		<p class=note>
@@ -802,11 +816,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		{{Clipboard/read()}} returns a {{Promise}} to [=clipboard items=] object that represents contents of [=system clipboard data=].
 		</p>
 
-		An <dfn>unsanitized</dfn> object is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=]. It contains <dfn>unsanitized mime types</dfn> that is currently limited to "text/html".
-
-		<p class="note">
-		In the future, other MIME types may be added.
-		</p>
+		{{ClipboardUnsanitizedFormats/unsanitized}} is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=] that are in the [=unsanitized data types=].
 
 		The <dfn>clipboard task source</dfn> is triggered in response to reading or writing of [=system clipboard data=].
 
@@ -819,15 +829,11 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			1. Let |p| be [=a new promise=] in |realm|.
 
-			1. Let |format| be a {{DOMString}}.
-
 			1. If |formats| is not empty, then:
 
-					1. If |formats|'s size is greater than 1, then [=reject=] |p| with {{"NotAllowedError"}} {{DOMException}} in |realm|.
+				1. For each |format| in |formats|["{{ClipboardUnsanitizedFormats/unsanitized}}"]:
 
-					1. Set |format| to |formats|[0].
-
-					1. If |format| is not in [=unsanitized mime types=], then [=reject=] |p| with {{"NotAllowedError"}} {{DOMException}} in |realm|.
+					1. If |format| is not in [=unsanitized data types=], then [=reject=] |p| with |format| {{"NotAllowedError"}} {{DOMException}} in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 
@@ -857,15 +863,23 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 						
 						1. Set |representation|'s [=representation/MIME type=] to |mimeType|.
 
+						1. Let |isUnsanitized| be |false|.
+
+						1. If |formats| is not empty, then:
+
+							1. For each |format| in |formats|["{{ClipboardUnsanitizedFormats/unsanitized}}"]:
+
+								1. If |format| is equal to [=representation/MIME type=], set |isUnsanitized| to true.
+
 						1. Set |representation|'s [=representation/data=] to |systemClipboardRepresentation|'s [=system clipboard representation/data=].
 
 							Issue: It should be possible to read the data asynchronously from the system clipboard after the author calls getType, however, this set of steps implies that data will be provided at the time of read.
 						
-						1. The user agent, MAY sanitize |representation|'s [=representation/data=], unless it satisfies the below conditions:
+						1. The user agent, MUST NOT sanitize |representation|'s [=representation/data=], if it satisfies the below conditions:
 						
 							1. |representation|'s [=representation/MIME type=]'s [=MIME type/essence=] is "image/png", which should remain unsanitized to preserve meta data.
 							
-							1. If |format| is not empty and |representation|'s [=representation/MIME type=]'s [=MIME type/essence=] is equal to |format|.
+							1. |isUnsanitized| is true.
 
 						1. Append |representation| to |item|'s [=list of representations=].
 					

--- a/index.bs
+++ b/index.bs
@@ -550,9 +550,9 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			* [=optional unsanitized data types=]
 
-			<p class=note>
-				The image/png MIME type is not sanitized to preserve meta data.
-			</p>
+			<dfn>Optional unsanitized data types</dfn> are [=representation/mime type=]s that MUST NOT be sanitized by the user agent. The valid [=optional unsanitized data types=] are listed below:
+
+			* text/html
 
 <h2 id="async-clipboard-api">Asynchronous Clipboard API</h2>
 
@@ -815,9 +815,6 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		</p>
 
 		{{ClipboardUnsanitizedFormats/unsanitized}} is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=] that the author wants to be treated as [=optional unsanitized data types=].
-		<dfn>Optional unsanitized data types</dfn> are [=representation/mime type=]s that MUST NOT be sanitized by the user agent. The valid [=optional unsanitized data types=] are listed below:
-
-			* text/html
 
 		The <dfn>clipboard task source</dfn> is triggered in response to reading or writing of [=system clipboard data=].
 

--- a/index.bs
+++ b/index.bs
@@ -782,10 +782,14 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 		[SecureContext, Exposed=Window]
 		interface Clipboard : EventTarget {
-			Promise&lt;ClipboardItems&gt; read();
+			Promise&lt;ClipboardItems&gt; read(optional ClipboardUnsanitizedFormats formats = {});
 			Promise&lt;DOMString&gt; readText();
 			Promise&lt;undefined&gt; write(ClipboardItems data);
 			Promise&lt;undefined&gt; writeText(DOMString data);
+		};
+
+		dictionary ClipboardUnsanitizedFormats {
+			sequence&lt;DOMString&gt; unsanitized;
 		};
 		</pre>
 
@@ -798,16 +802,32 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		{{Clipboard/read()}} returns a {{Promise}} to [=clipboard items=] object that represents contents of [=system clipboard data=].
 		</p>
 
+		An <dfn>unsanitized</dfn> object is a [=sequence=] of {{DOMString}} corresponding to the [=representation/mime type=].
+
+		<p class="note">
+		Only "text/html" MIME type is supported for [=unsanitized=] object. In the future, other MIME types may be added.
+		</p>
+
 		The <dfn>clipboard task source</dfn> is triggered in response to reading or writing of [=system clipboard data=].
 
 		<div id="clipboard-idl" dfn-for="Clipboard">
 		<div class="algorithm" data-algorithm="clipboard-read">
 		<h4 method for="Clipboard">read()</h4>
-		The {{Clipboard/read()}} method must run these steps:
+		The {{Clipboard/read(formats)}} method must run these steps:
 
 			1. Let |realm| be [=this=]'s [=relevant realm=].
 
 			1. Let |p| be [=a new promise=] in |realm|.
+
+			1. Let |format| be a {{DOMString}}.
+
+			1. If |formats| is not empty, then:
+
+					1. If |formats|'s size is greater than 1, then [=reject=] |p| with {{"NotAllowedError"}} {{DOMException}} in |realm|.
+
+					1. Set |format| to |formats|[0].
+
+					1. If |format| is not "text/html", then [=reject=] |p| with {{"NotAllowedError"}} {{DOMException}} in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 
@@ -841,7 +861,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 							Issue: It should be possible to read the data asynchronously from the system clipboard after the author calls getType, however, this set of steps implies that data will be provided at the time of read.
 						
-						1. The user agent, MAY sanitize |representation|'s [=representation/data=], unless |representation|'s [=representation/MIME type=]'s essence is "image/png", which should remain unsanitized to preserve meta data.
+						1. The user agent, MAY sanitize |representation|'s [=representation/data=], unless |representation|'s [=representation/MIME type=]'s [=MIME type/essence=] is "image/png", which should remain unsanitized to preserve meta data, or equal to |format| if |format| is not empty.
 
 						1. Append |representation| to |item|'s [=list of representations=].
 					

--- a/index.bs
+++ b/index.bs
@@ -548,6 +548,8 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			* image/png
 
+			* [=optional unsanitized data types=]
+
 			<p class=note>
 				The image/png MIME type is not sanitized to preserve meta data.
 			</p>
@@ -812,7 +814,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		{{Clipboard/read()}} returns a {{Promise}} to [=clipboard items=] object that represents contents of [=system clipboard data=].
 		</p>
 
-		{{ClipboardUnsanitizedFormats/unsanitized}} is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=] that are [=optional unsanitized data types=].
+		{{ClipboardUnsanitizedFormats/unsanitized}} is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=] that the author wants to be treated as [=optional unsanitized data types=].
 		<dfn>Optional unsanitized data types</dfn> are [=representation/mime type=]s that MUST NOT be sanitized by the user agent. The valid [=optional unsanitized data types=] are listed below:
 
 			* text/html

--- a/index.bs
+++ b/index.bs
@@ -827,7 +827,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 					1. Set |format| to |formats|[0].
 
-					1. If |format| is not [=unsanitized mime types=], then [=reject=] |p| with {{"NotAllowedError"}} {{DOMException}} in |realm|.
+					1. If |format| is not in [=unsanitized mime types=], then [=reject=] |p| with {{"NotAllowedError"}} {{DOMException}} in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 
@@ -861,7 +861,11 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 							Issue: It should be possible to read the data asynchronously from the system clipboard after the author calls getType, however, this set of steps implies that data will be provided at the time of read.
 						
-						1. The user agent, MAY sanitize |representation|'s [=representation/data=], unless |representation|'s [=representation/MIME type=]'s [=MIME type/essence=] is "image/png", which should remain unsanitized to preserve meta data, or equal to |format| if |format| is not empty.
+						1. The user agent, MAY sanitize |representation|'s [=representation/data=], unless it satisfies the below conditions:
+						
+							1. |representation|'s [=representation/MIME type=]'s [=MIME type/essence=] is "image/png", which should remain unsanitized to preserve meta data.
+							
+							1. If |format| is not empty and |representation|'s [=representation/MIME type=]'s [=MIME type/essence=] is equal to |format|.
 
 						1. Append |representation| to |item|'s [=list of representations=].
 					

--- a/index.bs
+++ b/index.bs
@@ -550,7 +550,8 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 			* [=optional unsanitized data types=]
 
-			<dfn>Optional unsanitized data types</dfn> are [=representation/mime type=]s that MUST NOT be sanitized by the user agent. The valid [=optional unsanitized data types=] are listed below:
+			<dfn>Optional unsanitized data types</dfn> are [=representation/mime type=]s specified by the web authors that MUST NOT be sanitized by the user agent.
+			The valid [=optional unsanitized data types=] are listed below:
 
 			* text/html
 

--- a/index.bs
+++ b/index.bs
@@ -802,17 +802,17 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		{{Clipboard/read()}} returns a {{Promise}} to [=clipboard items=] object that represents contents of [=system clipboard data=].
 		</p>
 
-		An <dfn>unsanitized</dfn> object is a [=sequence=] of {{DOMString}} corresponding to the [=representation/mime type=].
+		An <dfn>unsanitized</dfn> object is a [=sequence=] of {{DOMString}}s corresponding to the [=representation/mime type=]. It contains <dfn>unsanitized mime types</dfn> that is currently limited to "text/html".
 
 		<p class="note">
-		Only "text/html" MIME type is supported for [=unsanitized=] object. In the future, other MIME types may be added.
+		In the future, other MIME types may be added.
 		</p>
 
 		The <dfn>clipboard task source</dfn> is triggered in response to reading or writing of [=system clipboard data=].
 
 		<div id="clipboard-idl" dfn-for="Clipboard">
 		<div class="algorithm" data-algorithm="clipboard-read">
-		<h4 method for="Clipboard">read()</h4>
+		<h4 method for="Clipboard">read(|formats|)</h4>
 		The {{Clipboard/read(formats)}} method must run these steps:
 
 			1. Let |realm| be [=this=]'s [=relevant realm=].
@@ -827,7 +827,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 					1. Set |format| to |formats|[0].
 
-					1. If |format| is not "text/html", then [=reject=] |p| with {{"NotAllowedError"}} {{DOMException}} in |realm|.
+					1. If |format| is not [=unsanitized mime types=], then [=reject=] |p| with {{"NotAllowedError"}} {{DOMException}} in |realm|.
 
 			1. Run the following steps [=in parallel=]:
 

--- a/index.bs
+++ b/index.bs
@@ -546,7 +546,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 		The implementation MAY recognize the native OS clipboard format description
 		for the following data types, to be able to populate the
-		{{ClipboardItem}} with the correct description for paste events, and
+		{{ClipboardItem}} with the correct [=/MIME type=], and
 		set the correct data format on the OS clipboard in response to copy and cut
 		events.
 
@@ -882,6 +882,8 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 							1. |isUnsanitized| is true.
 
 						1. Append |representation| to |item|'s [=list of representations=].
+
+						1. Set |isUnsanitized| to |false|.
 					
 					1. If |item|'s [=list of representations=] size is greater than 0, append |item| to |items|.
 					


### PR DESCRIPTION
Closes #????

For normative changes, the following tasks have been completed:

 * [X] Modified Web platform tests (link to pull request) https://github.com/web-platform-tests/wpt/pull/35528

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [X] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1268679)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/197.html" title="Last updated on Nov 18, 2023, 1:29 AM UTC (0312e3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/197/ad65071...0312e3e.html" title="Last updated on Nov 18, 2023, 1:29 AM UTC (0312e3e)">Diff</a>