### PR TITLE
Allow empty ClipboardItem.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -654,7 +654,6 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 			1. Set |clipboardItemObject|'s [=/clipboard item=] to |clipboardItem|.
 
 		The <dfn constructor for="ClipboardItem" lt="ClipboardItem(items, options)"><code>new ClipboardItem(<var>items</var>, <var>options</var>)</code></dfn> constructor steps are:
-			1. If |items| is empty, then throw a {{TypeError}}.
 
 			1. If |options| is empty, then set options["presentationStyle"] = "unspecified".
 


### PR DESCRIPTION
Closes #179

For normative changes, the following tasks have been completed:

 * [X] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [X] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1500440)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/pull/198.html" title="Last updated on Nov 7, 2023, 11:32 PM UTC (26fcea7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/198/ad65071...26fcea7.html" title="Last updated on Nov 7, 2023, 11:32 PM UTC (26fcea7)">Diff</a>