### PR TITLE
The permission request stuff is no longer in contention

### DIFF
--- a/explainer.adoc
+++ b/explainer.adoc
@@ -230,10 +230,6 @@ The one case where permission must be explicitly requested is with the
 permission must have already been granted (either by requesting permission
 explicitly or by calling one of the read methods).
 
-IMPORTANT: The exact method for explicitly requesting a permission is still
-an active discussion. See
-link:https://github.com/w3c/permissions/issues/158[this permission bug].
-
 
 == Relationship to Current Clipboard API
 


### PR DESCRIPTION
I think.

I also think that a great deal more needs to be done with this explainer to get up to speed, so this change might not be appropriate at this time.

For instance, I think that the clipboardchange event is no longer really a thing (which would be good).

For normative changes, the following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
 
