### PR TITLE
Split implementor interest and implementation bugs from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,12 @@
 Closes #????
 
 For normative changes, the following tasks have been completed:
-
+ * [ ] At least two implementers are interested (and none opposed):
+   * …
+   * …
  * [ ] Modified Web platform tests (link to pull request)
 
-Implementation commitment:
+Implementation bugs are filed:
 
  * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
  * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)


### PR DESCRIPTION
Closes #207

I did not completely replace the existing template with the WHATWG one, although I would be okay with that.

Once we do this, we should make sure other Editing WG repositories get the same templates.