### PR TITLE
Fix ClipboardEvent example to include `eventInitDict` param

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -198,7 +198,9 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 		An example is given below:
 
 		<pre class="example javascript">
-			var pasteEvent = new ClipboardEvent('paste');
+			var pasteEvent = new ClipboardEvent('paste', {
+				clipboardData: new DataTransfer()
+			});
 			pasteEvent.clipboardData.items.add('My string', 'text/plain');
 			document.dispatchEvent(pasteEvent);
 		</pre>


### PR DESCRIPTION
Omitting `eventInitDict` resulted in `pasteEvent.clipboardData` being `null`, which caused an error when calling`pasteEvent.clipboardData.items.add`.
 
