### PR TITLE
chore: fix markup errors for the automatic publication

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1932,7 +1932,8 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 			1. Append |representation| to |item|'s [=list of representations=].
 
 	</div><!-- algorithm -->
-
+    
+    <div class="algorithm" data-algorithm="read-web-custom-format">
 	<h3 id="to-write-web-custom-formats"><dfn>write web custom formats</dfn></h3>
 
 		: Input

--- a/index.bs
+++ b/index.bs
@@ -12,7 +12,7 @@ Repository: w3c/clipboard-apis
 !Explainer: <a href="https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc">Async Clipboard API Explainer</a>
 Editor: Gary Kacmarcik, Google, garykac@google.com, w3cid 59482
 Editor: Anupam Snigdha, Microsoft, snianu@microsoft.com, w3cid 126950
-Former Editor: Hallvord R. M. Steen, Mozilla
+Former Editor: Hallvord R. M. Steen, Mozilla, hsteen@mozilla.com, w3cid 42065
 Former Editor: Grisha Lyukshin, Microsoft, glyuk@microsoft.com, w3cid 78883
 Abstract:
 	This document describes APIs for accessing data on the system clipboard. It provides

--- a/index.bs
+++ b/index.bs
@@ -1933,7 +1933,7 @@ url: https://w3c.github.io/permissions/#permissions-task-source; type: dfn;
 
 	</div><!-- algorithm -->
     
-    <div class="algorithm" data-algorithm="read-web-custom-format">
+    <div class="algorithm" data-algorithm="write-web-custom-format">
 	<h3 id="to-write-web-custom-formats"><dfn>write web custom formats</dfn></h3>
 
 		: Input


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/siusin/clipboard-apis/pull/234.html" title="Last updated on Mar 18, 2025, 10:36 AM UTC (7087ea6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/234/2eebe17...siusin:7087ea6.html" title="Last updated on Mar 18, 2025, 10:36 AM UTC (7087ea6)">Diff</a>