### PR TITLE
Update Editor List - Add New Editors and Move Former Editors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,8 +10,10 @@ ED: https://w3c.github.io/clipboard-apis/
 Previous Version: from biblio
 Repository: w3c/clipboard-apis
 !Explainer: <a href="https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc">Async Clipboard API Explainer</a>
-Editor: Gary Kacmarcik, Google, garykac@google.com, w3cid 59482
-Editor: Anupam Snigdha, Microsoft, snianu@microsoft.com, w3cid 126950
+Editor: Rakesh Goulikar, Microsoft, ragoulik@microsoft.com, w3cid 153330
+Editor: Rohan Raja, Microsoft, roraja@microsoft.com, w3cid 159843
+Former Editor: Gary Kacmarcik, Google, garykac@google.com, w3cid 59482
+Former Editor: Anupam Snigdha, Microsoft, snianu@microsoft.com, w3cid 126950
 Former Editor: Hallvord R. M. Steen, Mozilla, hsteen@mozilla.com, w3cid 42065
 Former Editor: Grisha Lyukshin, Microsoft, glyuk@microsoft.com, w3cid 78883
 Abstract:


### PR DESCRIPTION
This PR updates the editor list by adding Rakesh Goulikar and Rohan Raja as current editors, and moving Gary Kacmarcik and Anupam Snigdha to former editors.

Note: This is a non-normative change (editorial metadata update only). The normative checklist below has been removed as it does not apply to this change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/roraja/clipboard-apis/pull/245.html" title="Last updated on Nov 14, 2025, 2:20 AM UTC (f56c74a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clipboard-apis/245/c3ba452...roraja:f56c74a.html" title="Last updated on Nov 14, 2025, 2:20 AM UTC (f56c74a)">Diff</a>